### PR TITLE
fix: prune old boot kernel pairs

### DIFF
--- a/pkg/update.go
+++ b/pkg/update.go
@@ -960,6 +960,8 @@ func (u *SystemUpdater) InstallKernelAndInitramfs() error {
 	previousKernelVersion, err := u.getActiveRootKernelVersion()
 	if err != nil {
 		p.Warning("failed to determine previous kernel version: %v", err)
+		p.Warning("skipping /boot kernel pruning to avoid removing the currently booted kernel")
+		return nil
 	}
 
 	if err := pruneBootKernelPairs(kernelDestDir, currentKernelVersion, previousKernelVersion, p); err != nil {

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1379,11 +1379,14 @@ func (u *SystemUpdater) updateSystemdBootBootloader() error {
 
 	previousKernelVersion, err := u.getActiveRootKernelVersion()
 	if err != nil {
-		return fmt.Errorf("failed to get previous kernel version: %w", err)
+		u.Progress.Warning("failed to get previous kernel version, falling back to current kernel for rollback entry: %v", err)
+		previousKernelVersion = kernelVersion
 	}
 	previousInitrd, err := getBootInitramfsName(u.Config.BootMountPoint, previousKernelVersion)
 	if err != nil {
-		return err
+		u.Progress.Warning("failed to find initramfs for previous kernel %s, falling back to current initramfs for rollback entry: %v", previousKernelVersion, err)
+		previousKernelVersion = kernelVersion
+		previousInitrd = initrd
 	}
 
 	// Create/update rollback boot entry (points to previous system)

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1264,11 +1264,14 @@ func (u *SystemUpdater) updateGRUBBootloader() error {
 
 	previousKernelVersion, err := u.getActiveRootKernelVersion()
 	if err != nil {
-		return fmt.Errorf("failed to get previous kernel version: %w", err)
+		u.Progress.Warning("failed to get previous kernel version, falling back to current kernel for rollback entry: %v", err)
+		previousKernelVersion = kernelVersion
 	}
 	previousInitrd, err := getBootInitramfsName(u.Config.BootMountPoint, previousKernelVersion)
 	if err != nil {
-		return err
+		u.Progress.Warning("failed to find initramfs for previous kernel %s, falling back to current initramfs for rollback entry: %v", previousKernelVersion, err)
+		previousKernelVersion = kernelVersion
+		previousInitrd = initrd
 	}
 
 	grubCfg := buildGRUBConfig(osName, kernelVersion, initrd, kernelCmdline, previousKernelVersion, previousInitrd, previousCmdline)

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -952,7 +952,118 @@ func (u *SystemUpdater) InstallKernelAndInitramfs() error {
 		p.Message("Kernel and initramfs are up to date")
 	}
 
+	currentKernelVersion, err := u.getUpdatedRootKernelVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get current kernel version: %w", err)
+	}
+
+	previousKernelVersion, err := u.getActiveRootKernelVersion()
+	if err != nil {
+		p.Warning("failed to determine previous kernel version: %v", err)
+	}
+
+	if err := pruneBootKernelPairs(kernelDestDir, currentKernelVersion, previousKernelVersion, p); err != nil {
+		return fmt.Errorf("failed to prune old boot kernels: %w", err)
+	}
+
 	return nil
+}
+
+func (u *SystemUpdater) getActiveRootKernelVersion() (string, error) {
+	return readRunningKernelVersion("/proc/sys/kernel/osrelease")
+}
+
+func readRunningKernelVersion(path string) (string, error) {
+	version, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read running kernel version: %w", err)
+	}
+	trimmed := strings.TrimSpace(string(version))
+	if trimmed == "" {
+		return "", fmt.Errorf("running kernel version is empty")
+	}
+	return trimmed, nil
+}
+
+type bootKernelPair struct {
+	version string
+	kernel  string
+	initrd  string
+}
+
+func findBootKernelPairs(bootDir string) ([]bootKernelPair, error) {
+	kernels, err := filepath.Glob(filepath.Join(bootDir, "vmlinuz-*"))
+	if err != nil {
+		return nil, err
+	}
+
+	pairs := make([]bootKernelPair, 0, len(kernels))
+	for _, kernel := range kernels {
+		version := strings.TrimPrefix(filepath.Base(kernel), "vmlinuz-")
+		initrd, ok := findBootInitramfs(bootDir, version)
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, bootKernelPair{
+			version: version,
+			kernel:  kernel,
+			initrd:  initrd,
+		})
+	}
+
+	return pairs, nil
+}
+
+func findBootInitramfs(bootDir, version string) (string, bool) {
+	patterns := []string{
+		filepath.Join(bootDir, "initramfs-"+version+".img"),
+		filepath.Join(bootDir, "initrd.img-"+version),
+		filepath.Join(bootDir, "initramfs-"+version),
+	}
+	for _, pattern := range patterns {
+		if info, err := os.Stat(pattern); err == nil && !info.IsDir() {
+			return pattern, true
+		}
+	}
+	return "", false
+}
+
+func pruneBootKernelPairs(bootDir, currentVersion, previousVersion string, progress reporter.Reporter) error {
+	pairs, err := findBootKernelPairs(bootDir)
+	if err != nil {
+		return fmt.Errorf("failed to find boot kernel pairs: %w", err)
+	}
+
+	keep := map[string]bool{
+		currentVersion: true,
+	}
+	if previousVersion != "" {
+		keep[previousVersion] = true
+	}
+
+	for _, pair := range pairs {
+		if keep[pair.version] {
+			continue
+		}
+
+		if err := os.Remove(pair.kernel); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove old kernel %s: %w", filepath.Base(pair.kernel), err)
+		}
+		if err := os.Remove(pair.initrd); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove old initramfs %s: %w", filepath.Base(pair.initrd), err)
+		}
+		progress.Message("Pruned old boot kernel pair: %s", pair.version)
+	}
+
+	return nil
+}
+
+func getBootInitramfsName(bootDir, version string) (string, error) {
+	initrd, ok := findBootInitramfs(bootDir, version)
+	if !ok {
+		return "", fmt.Errorf("initramfs for kernel %s not found on boot partition", version)
+	}
+	return filepath.Base(initrd), nil
 }
 
 // detectBootloaderTypeFromMount detects bootloader from already-mounted boot partition
@@ -1033,7 +1144,11 @@ func (u *SystemUpdater) detectBootloaderType() BootloaderType {
 // This ensures we use the kernel version from the newly extracted image, not a random kernel
 // from the boot partition which might be a different version.
 func (u *SystemUpdater) getUpdatedRootKernelVersion() (string, error) {
-	modulesDir := filepath.Join(u.Config.MountPoint, "usr", "lib", "modules")
+	return getKernelVersionFromRoot(u.Config.MountPoint)
+}
+
+func getKernelVersionFromRoot(root string) (string, error) {
+	modulesDir := filepath.Join(root, "usr", "lib", "modules")
 	entries, err := os.ReadDir(modulesDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to read modules directory: %w", err)
@@ -1093,18 +1208,9 @@ func (u *SystemUpdater) updateGRUBBootloader() error {
 		return fmt.Errorf("kernel vmlinuz-%s not found on boot partition (should have been copied earlier): %w", kernelVersion, err)
 	}
 
-	// Look for initramfs
-	var initrd string
-	initrdPatterns := []string{
-		filepath.Join(u.Config.BootMountPoint, "initramfs-"+kernelVersion+".img"),
-		filepath.Join(u.Config.BootMountPoint, "initrd.img-"+kernelVersion),
-		filepath.Join(u.Config.BootMountPoint, "initramfs-"+kernelVersion),
-	}
-	for _, pattern := range initrdPatterns {
-		if _, err := os.Stat(pattern); err == nil {
-			initrd = filepath.Base(pattern)
-			break
-		}
+	initrd, err := getBootInitramfsName(u.Config.BootMountPoint, kernelVersion)
+	if err != nil {
+		return err
 	}
 
 	// Get filesystem type (default to ext4 for backward compatibility)
@@ -1154,7 +1260,28 @@ func (u *SystemUpdater) updateGRUBBootloader() error {
 		return fmt.Errorf("failed to build previous kernel cmdline: %w", err)
 	}
 
-	grubCfg := fmt.Sprintf(`set timeout=5
+	previousKernelVersion, err := u.getActiveRootKernelVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get previous kernel version: %w", err)
+	}
+	previousInitrd, err := getBootInitramfsName(u.Config.BootMountPoint, previousKernelVersion)
+	if err != nil {
+		return err
+	}
+
+	grubCfg := buildGRUBConfig(osName, kernelVersion, initrd, kernelCmdline, previousKernelVersion, previousInitrd, previousCmdline)
+
+	grubCfgPath := filepath.Join(grubDir, "grub.cfg")
+	if err := os.WriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
+		return fmt.Errorf("failed to write grub.cfg: %w", err)
+	}
+
+	u.Progress.Message("  Updated GRUB to boot from %s", u.Target)
+	return nil
+}
+
+func buildGRUBConfig(osName, currentKernelVersion, currentInitrd string, currentCmdline []string, previousKernelVersion, previousInitrd string, previousCmdline []string) string {
+	return fmt.Sprintf(`set timeout=5
 set default=0
 
 menuentry '%s' {
@@ -1166,16 +1293,8 @@ menuentry '%s (Previous)' {
     linux /vmlinuz-%s %s
     initrd /%s
 }
-`, osName, kernelVersion, strings.Join(kernelCmdline, " "), initrd,
-		osName, kernelVersion, strings.Join(previousCmdline, " "), initrd)
-
-	grubCfgPath := filepath.Join(grubDir, "grub.cfg")
-	if err := os.WriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
-		return fmt.Errorf("failed to write grub.cfg: %w", err)
-	}
-
-	u.Progress.Message("  Updated GRUB to boot from %s", u.Target)
-	return nil
+`, osName, currentKernelVersion, strings.Join(currentCmdline, " "), currentInitrd,
+		osName, previousKernelVersion, strings.Join(previousCmdline, " "), previousInitrd)
 }
 
 // updateSystemdBootBootloader updates systemd-boot configuration
@@ -1211,18 +1330,9 @@ func (u *SystemUpdater) updateSystemdBootBootloader() error {
 		return fmt.Errorf("kernel vmlinuz-%s not found on boot partition (should have been copied earlier): %w", kernelVersion, err)
 	}
 
-	// Look for initramfs on boot partition
-	var initrd string
-	initrdPatterns := []string{
-		filepath.Join(u.Config.BootMountPoint, "initramfs-"+kernelVersion+".img"),
-		filepath.Join(u.Config.BootMountPoint, "initrd.img-"+kernelVersion),
-		filepath.Join(u.Config.BootMountPoint, "initramfs-"+kernelVersion),
-	}
-	for _, pattern := range initrdPatterns {
-		if _, err := os.Stat(pattern); err == nil {
-			initrd = filepath.Base(pattern)
-			break
-		}
+	initrd, err := getBootInitramfsName(u.Config.BootMountPoint, kernelVersion)
+	if err != nil {
+		return err
 	}
 
 	// Get filesystem type (default to ext4 for backward compatibility)
@@ -1249,11 +1359,7 @@ func (u *SystemUpdater) updateSystemdBootBootloader() error {
 		return fmt.Errorf("failed to create entries directory: %w", err)
 	}
 
-	mainEntry := fmt.Sprintf(`title   %s
-linux   /vmlinuz-%s
-initrd  /%s
-options %s
-`, osName, kernelVersion, initrd, strings.Join(kernelCmdline, " "))
+	mainEntry := buildSystemdBootEntry(osName, kernelVersion, initrd, kernelCmdline)
 
 	mainEntryPath := filepath.Join(entriesDir, "bootc.conf")
 	if err := os.WriteFile(mainEntryPath, []byte(mainEntry), 0644); err != nil {
@@ -1266,12 +1372,17 @@ options %s
 		return fmt.Errorf("failed to build previous kernel cmdline: %w", err)
 	}
 
+	previousKernelVersion, err := u.getActiveRootKernelVersion()
+	if err != nil {
+		return fmt.Errorf("failed to get previous kernel version: %w", err)
+	}
+	previousInitrd, err := getBootInitramfsName(u.Config.BootMountPoint, previousKernelVersion)
+	if err != nil {
+		return err
+	}
+
 	// Create/update rollback boot entry (points to previous system)
-	previousEntry := fmt.Sprintf(`title   %s (Previous)
-linux   /vmlinuz-%s
-initrd  /%s
-options %s
-`, osName, kernelVersion, initrd, strings.Join(previousCmdline, " "))
+	previousEntry := buildSystemdBootEntry(osName+" (Previous)", previousKernelVersion, previousInitrd, previousCmdline)
 
 	previousEntryPath := filepath.Join(entriesDir, "bootc-previous.conf")
 	if err := os.WriteFile(previousEntryPath, []byte(previousEntry), 0644); err != nil {
@@ -1280,6 +1391,14 @@ options %s
 
 	u.Progress.Message("Updated systemd-boot to boot from %s", u.Target)
 	return nil
+}
+
+func buildSystemdBootEntry(title, kernelVersion, initrd string, cmdline []string) string {
+	return fmt.Sprintf(`title   %s
+linux   /vmlinuz-%s
+initrd  /%s
+options %s
+`, title, kernelVersion, initrd, strings.Join(cmdline, " "))
 }
 
 // PerformUpdate performs the complete update workflow

--- a/pkg/update_test.go
+++ b/pkg/update_test.go
@@ -945,6 +945,159 @@ ID=test
 	})
 }
 
+func TestPruneBootKernelPairsKeepsCurrentAndPrevious(t *testing.T) {
+	bootDir := t.TempDir()
+
+	versions := []string{"6.18.1-old", "6.18.2-previous", "6.18.3-current"}
+	for _, version := range versions {
+		if err := os.WriteFile(filepath.Join(bootDir, "vmlinuz-"+version), []byte("kernel"), 0644); err != nil {
+			t.Fatalf("Failed to write kernel: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(bootDir, "initramfs-"+version+".img"), []byte("initramfs"), 0644); err != nil {
+			t.Fatalf("Failed to write initramfs: %v", err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(bootDir, "BOOTX64.EFI"), []byte("efi"), 0644); err != nil {
+		t.Fatalf("Failed to write unrelated EFI file: %v", err)
+	}
+
+	if err := pruneBootKernelPairs(bootDir, "6.18.3-current", "6.18.2-previous", reporter.NoopReporter{}); err != nil {
+		t.Fatalf("pruneBootKernelPairs failed: %v", err)
+	}
+
+	for _, kept := range []string{"6.18.3-current", "6.18.2-previous"} {
+		if _, err := os.Stat(filepath.Join(bootDir, "vmlinuz-"+kept)); err != nil {
+			t.Errorf("Expected kernel %s to remain: %v", kept, err)
+		}
+		if _, err := os.Stat(filepath.Join(bootDir, "initramfs-"+kept+".img")); err != nil {
+			t.Errorf("Expected initramfs %s to remain: %v", kept, err)
+		}
+	}
+
+	for _, removed := range []string{
+		"vmlinuz-6.18.1-old",
+		"initramfs-6.18.1-old.img",
+	} {
+		if _, err := os.Stat(filepath.Join(bootDir, removed)); !os.IsNotExist(err) {
+			t.Errorf("Expected %s to be pruned", removed)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(bootDir, "BOOTX64.EFI")); err != nil {
+		t.Errorf("Expected unrelated EFI file to remain: %v", err)
+	}
+}
+
+func TestPruneBootKernelPairsLeavesIncompletePairs(t *testing.T) {
+	bootDir := t.TempDir()
+
+	completeVersions := []string{"6.18.2-previous", "6.18.3-current"}
+	for _, version := range completeVersions {
+		if err := os.WriteFile(filepath.Join(bootDir, "vmlinuz-"+version), []byte("kernel"), 0644); err != nil {
+			t.Fatalf("Failed to write kernel: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(bootDir, "initrd.img-"+version), []byte("initramfs"), 0644); err != nil {
+			t.Fatalf("Failed to write initramfs: %v", err)
+		}
+	}
+
+	orphans := []string{
+		"vmlinuz-6.18.0-orphan",
+		"initramfs-6.18.1-orphan.img",
+		"loader.conf",
+	}
+	for _, orphan := range orphans {
+		if err := os.WriteFile(filepath.Join(bootDir, orphan), []byte("orphan"), 0644); err != nil {
+			t.Fatalf("Failed to write orphan file: %v", err)
+		}
+	}
+
+	if err := pruneBootKernelPairs(bootDir, "6.18.3-current", "6.18.2-previous", reporter.NoopReporter{}); err != nil {
+		t.Fatalf("pruneBootKernelPairs failed: %v", err)
+	}
+
+	for _, orphan := range orphans {
+		if _, err := os.Stat(filepath.Join(bootDir, orphan)); err != nil {
+			t.Errorf("Expected incomplete/unrelated file %s to remain: %v", orphan, err)
+		}
+	}
+}
+
+func TestGetKernelVersionFromRoot(t *testing.T) {
+	root := t.TempDir()
+	modulesBase := filepath.Join(root, "usr", "lib", "modules")
+
+	for _, version := range []string{"6.18.2-previous", "6.18.3-current"} {
+		kernelDir := filepath.Join(modulesBase, version)
+		if err := os.MkdirAll(kernelDir, 0755); err != nil {
+			t.Fatalf("Failed to create modules directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(kernelDir, "vmlinuz"), []byte("kernel"), 0644); err != nil {
+			t.Fatalf("Failed to write vmlinuz: %v", err)
+		}
+	}
+
+	version, err := getKernelVersionFromRoot(root)
+	if err != nil {
+		t.Fatalf("getKernelVersionFromRoot failed: %v", err)
+	}
+	if version != "6.18.3-current" {
+		t.Errorf("getKernelVersionFromRoot = %q, want %q", version, "6.18.3-current")
+	}
+}
+
+func TestReadRunningKernelVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "osrelease")
+	if err := os.WriteFile(path, []byte("6.18.2-previous\n"), 0644); err != nil {
+		t.Fatalf("Failed to write osrelease: %v", err)
+	}
+
+	version, err := readRunningKernelVersion(path)
+	if err != nil {
+		t.Fatalf("readRunningKernelVersion failed: %v", err)
+	}
+	if version != "6.18.2-previous" {
+		t.Errorf("readRunningKernelVersion = %q, want %q", version, "6.18.2-previous")
+	}
+}
+
+func TestBuildSystemdBootEntryUsesRequestedKernelVersion(t *testing.T) {
+	entry := buildSystemdBootEntry("Test Linux", "6.18.2-previous", "initramfs-6.18.2-previous.img", []string{"root=UUID=previous", "ro"})
+
+	if !strings.Contains(entry, "linux   /vmlinuz-6.18.2-previous") {
+		t.Errorf("entry should reference previous kernel, got:\n%s", entry)
+	}
+	if !strings.Contains(entry, "initrd  /initramfs-6.18.2-previous.img") {
+		t.Errorf("entry should reference previous initramfs, got:\n%s", entry)
+	}
+	if strings.Contains(entry, "6.18.3-current") {
+		t.Errorf("entry should not reference current kernel, got:\n%s", entry)
+	}
+}
+
+func TestBuildGRUBConfigUsesPreviousKernelForPreviousEntry(t *testing.T) {
+	config := buildGRUBConfig(
+		"Test Linux",
+		"6.18.3-current",
+		"initramfs-6.18.3-current.img",
+		[]string{"root=UUID=current", "ro"},
+		"6.18.2-previous",
+		"initramfs-6.18.2-previous.img",
+		[]string{"root=UUID=previous", "ro"},
+	)
+
+	if !strings.Contains(config, "menuentry 'Test Linux (Previous)'") {
+		t.Errorf("config should contain previous entry, got:\n%s", config)
+	}
+	if !strings.Contains(config, "linux /vmlinuz-6.18.2-previous root=UUID=previous ro") {
+		t.Errorf("previous entry should reference previous kernel, got:\n%s", config)
+	}
+	if !strings.Contains(config, "initrd /initramfs-6.18.2-previous.img") {
+		t.Errorf("previous entry should reference previous initramfs, got:\n%s", config)
+	}
+}
+
 func readConfigFromFile(path string) (*SystemConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
## Summary
- prune /boot to keep only current and previous complete kernel/initramfs pairs during update
- use the running kernel for rollback boot entries instead of reusing the new kernel
- add tests for pruning and boot entry generation

## Verification
- make fmt
- make test-unit
- make build