### PR TITLE
fix(etc-overlay): stop seeding upper layer with container /etc (#84)

### DIFF
--- a/pkg/dracut/95etc-overlay/etc-overlay-mount.sh
+++ b/pkg/dracut/95etc-overlay/etc-overlay-mount.sh
@@ -17,6 +17,78 @@ SYSROOT="${NEWROOT:-/sysroot}"
 # not here. Creating it here would be lost when systemd mounts a fresh
 # tmpfs on /run after switch_root.
 
+# prepare_etc_lower reconciles the overlay lower directory (.etc.lower) with the
+# root filesystem's /etc so the overlay can be mounted with a populated,
+# read-only lower layer and a CLEAN upper layer (user modifications only).
+#
+# Design (see docs/ETC-OVERLAY.md):
+#   - lowerdir = /.etc.lower   (base /etc from the container image, read-only)
+#   - upperdir = /var/lib/nbc/etc-overlay/upper  (user modifications ONLY)
+#
+# nbc pre-populates /.etc.lower with the container's /etc at install/update time.
+# In that (normal) case we MUST leave the layers untouched: the overlay mount
+# over /etc simply shadows the identical copy on the root filesystem, and the
+# lower layer supplies the defaults. Copying the root fs /etc into the upper
+# layer here would pin the container defaults in the writable upper and
+# permanently shadow future A/B updates -- silently defeating /etc updates.
+#
+# Only when /.etc.lower is empty/missing (its lower layer was never seeded) do we
+# seed it by moving the root fs /etc into place.
+#
+# Globals set for the caller:
+#   ETC_LOWER_DIR - path to the lower layer directory
+#   ROOT_WAS_RO   - 1 if we remounted the root rw and it must be restored
+#   ETC_MOVED     - 1 if we moved /etc into .etc.lower (affects failure rollback)
+# Reads global: ETC_LOWER (path to the root fs /etc), SYSROOT
+prepare_etc_lower() {
+    ETC_LOWER_DIR="$SYSROOT/.etc.lower"
+    ROOT_WAS_RO=0
+    ETC_MOVED=0
+
+    # Normal case: nbc already populated the lower layer (or a previous boot
+    # seeded it). Use it as-is; do NOT seed the upper layer.
+    if [ -d "$ETC_LOWER_DIR" ] && [ -n "$(ls -A "$ETC_LOWER_DIR" 2>/dev/null)" ]; then
+        info "etc-overlay: Using populated lower layer at $ETC_LOWER_DIR"
+        return 0
+    fi
+
+    # Fallback: lower layer is empty/missing -> seed it from the root fs /etc.
+    #
+    # We may need to temporarily remount the root rw to move /etc.
+    # /proc/mounts format: device mountpoint fstype options dump pass
+    # The 'ro' option is in the 4th field (options), as a comma-separated entry
+    # that can appear anywhere (e.g., "ro", "relatime,ro", "defaults,ro,noatime").
+    if grep -E "^[^ ]+ $SYSROOT [^ ]+ ([^ ]*,)?ro(,[^ ]*)?( |$)" /proc/mounts >/dev/null 2>&1; then
+        info "etc-overlay: Root is mounted read-only, temporarily remounting rw"
+        ROOT_WAS_RO=1
+        if ! mount -o remount,rw "$SYSROOT"; then
+            warn "etc-overlay: Failed to remount root rw, cannot setup overlay"
+            return 1
+        fi
+    fi
+
+    # Remove an empty .etc.lower placeholder if present (created by nbc during
+    # install). This must happen AFTER the ro remount check above.
+    if [ -d "$ETC_LOWER_DIR" ]; then
+        rm -rf "$ETC_LOWER_DIR"
+    fi
+
+    if ! mv "$ETC_LOWER" "$ETC_LOWER_DIR"; then
+        warn "etc-overlay: Failed to move original /etc"
+        if [ "$ROOT_WAS_RO" = "1" ]; then
+            mount -o remount,ro "$SYSROOT" 2>/dev/null || true
+        fi
+        return 1
+    fi
+    ETC_MOVED=1
+
+    return 0
+}
+
+# Allow tests to source this file and exercise prepare_etc_lower() in isolation
+# without running the boot-time flow below.
+[ -n "${ETC_OVERLAY_TEST:-}" ] && return 0
+
 # Check if overlay is enabled
 if ! getargbool 0 rd.etc.overlay; then
     info "etc-overlay: rd.etc.overlay not enabled, skipping overlay setup"
@@ -130,69 +202,13 @@ fi
 # - workdir: required by overlayfs for atomic operations
 info "etc-overlay: Mounting overlay (lower=$ETC_LOWER, upper=$OVERLAY_UPPER)"
 
-# We need to move the original /etc to a hidden location because overlayfs
-# requires lowerdir to be a separate path from the mount point.
-# Use a consistent hidden name so it's predictable.
-ETC_LOWER_DIR="$SYSROOT/.etc.lower"
-
-# Check if we already have a lower dir from a previous boot
-# This happens on subsequent boots - reuse the existing lower layer
-if [ -d "$ETC_LOWER_DIR" ] && [ "$(ls -A "$ETC_LOWER_DIR" 2>/dev/null)" ]; then
-    # Previous lower dir exists with content - this is a normal reboot
-    info "etc-overlay: Reusing existing lower layer at $ETC_LOWER_DIR"
-    # Check if current /etc is empty (just a mount point from before)
-    if [ ! "$(ls -A "$ETC_LOWER" 2>/dev/null)" ]; then
-        info "etc-overlay: Current /etc is empty mount point, will overlay on existing lower"
-    else
-        # /etc has content - this shouldn't happen, but handle gracefully
-        # The current /etc might be leftover from a failed overlay attempt
-        info "etc-overlay: Current /etc has content, merging with lower layer"
-        # Copy any new files from /etc to upper layer (they are customizations)
-        # Avoid overwriting existing entries in the upper layer to preserve user changes
-        for src in "$ETC_LOWER"/*; do
-            # Handle case where the glob doesn't match anything
-            [ -e "$src" ] || continue
-            name=${src##*/}  # basename
-            if [ -e "$OVERLAY_UPPER/$name" ]; then
-                info "etc-overlay: Skipping existing upper-layer entry: $name"
-                continue
-            fi
-            cp -a "$src" "$OVERLAY_UPPER/" 2>/dev/null || true
-        done
-    fi
-else
-    # First boot or lower dir is empty/missing - move /etc to lower dir
-
-    # Check if root is mounted read-only (ro kernel parameter)
-    # We need to temporarily remount rw to move /etc
-    # /proc/mounts format: device mountpoint fstype options dump pass
-    # The 'ro' option is in the 4th field (options), as a comma-separated entry that can
-    # appear anywhere in the list (e.g., "ro", "relatime,ro", "defaults,ro,noatime")
-    ROOT_WAS_RO=0
-    # Use grep to find the mount line for $SYSROOT and check for a 'ro' option anywhere
-    if grep -E "^[^ ]+ $SYSROOT [^ ]+ ([^ ]*,)?ro(,[^ ]*)?( |$)" /proc/mounts >/dev/null 2>&1; then
-        info "etc-overlay: Root is mounted read-only, temporarily remounting rw"
-        ROOT_WAS_RO=1
-        if ! mount -o remount,rw "$SYSROOT"; then
-            warn "etc-overlay: Failed to remount root rw, cannot setup overlay"
-            return 0
-        fi
-    fi
-
-    # Remove empty .etc.lower if it exists (created by nbc during install)
-    # This must happen AFTER the ro remount check above
-    if [ -d "$ETC_LOWER_DIR" ]; then
-        rm -rf "$ETC_LOWER_DIR"
-    fi
-
-    if ! mv "$ETC_LOWER" "$ETC_LOWER_DIR"; then
-        warn "etc-overlay: Failed to move original /etc"
-        # Restore ro if we changed it
-        if [ "$ROOT_WAS_RO" = "1" ]; then
-            mount -o remount,ro "$SYSROOT" 2>/dev/null || true
-        fi
-        return 0
-    fi
+# We need the original /etc content available at a hidden location because
+# overlayfs requires lowerdir to be a separate path from the mount point.
+# prepare_etc_lower sets ETC_LOWER_DIR (and, if it had to seed the lower layer,
+# ROOT_WAS_RO / ETC_MOVED for the rollback/restore paths below).
+if ! prepare_etc_lower; then
+    warn "etc-overlay: Failed to prepare lower layer, /etc overlay disabled"
+    return 0
 fi
 
 # Create/ensure the mount point exists
@@ -218,8 +234,11 @@ if mount -t overlay overlay \
     fi
 else
     warn "etc-overlay: Failed to mount overlay, restoring original /etc"
-    rmdir "$ETC_LOWER" 2>/dev/null
-    mv "$ETC_LOWER_DIR" "$ETC_LOWER"
+    # Only undo the move if prepare_etc_lower actually moved /etc into .etc.lower.
+    if [ "${ETC_MOVED:-0}" = "1" ]; then
+        rmdir "$ETC_LOWER" 2>/dev/null
+        mv "$ETC_LOWER_DIR" "$ETC_LOWER"
+    fi
     # Restore ro if we changed it
     if [ "${ROOT_WAS_RO:-0}" = "1" ]; then
         mount -o remount,ro "$SYSROOT" 2>/dev/null || true

--- a/pkg/etc_overlay_hook_test.go
+++ b/pkg/etc_overlay_hook_test.go
@@ -119,7 +119,10 @@ func TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper(t *testing.T) {
 	// The core assertion: upper must remain empty. On the buggy hook it gets the
 	// entire /etc copied into it.
 	if got := countEntries(t, upper); got != 0 {
-		names, _ := os.ReadDir(upper)
+		names, err := os.ReadDir(upper)
+		if err != nil {
+			t.Fatalf("failed to read upper dir: %v", err)
+		}
 		var polluted []string
 		for _, n := range names {
 			polluted = append(polluted, n.Name())

--- a/pkg/etc_overlay_hook_test.go
+++ b/pkg/etc_overlay_hook_test.go
@@ -1,0 +1,157 @@
+package pkg
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// hookPath returns the path to the dracut etc-overlay hook script relative to
+// this package directory.
+func hookPath(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join("dracut", "95etc-overlay", "etc-overlay-mount.sh")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("hook script not found at %s: %v", p, err)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatalf("failed to resolve hook path: %v", err)
+	}
+	return abs
+}
+
+// runPrepareEtcLower sources the real hook with ETC_OVERLAY_TEST=1 (which makes
+// it define its functions and return before running the boot-time flow), then
+// invokes prepare_etc_lower() against the provided sandbox sysroot. It returns
+// the function's exit status via the error.
+func runPrepareEtcLower(t *testing.T, sysroot string) error {
+	t.Helper()
+	hook := hookPath(t)
+	// Stub the dracut helpers the hook expects, point SYSROOT/ETC_LOWER at the
+	// sandbox, source the hook (returns at the ETC_OVERLAY_TEST guard), then run
+	// only the lower-layer reconciliation logic.
+	script := `
+set -e
+getarg() { :; }
+getargbool() { return 1; }
+info() { :; }
+warn() { :; }
+export ETC_OVERLAY_TEST=1
+SYSROOT="$1"
+. "$2"
+SYSROOT="$1"
+ETC_LOWER="$SYSROOT/etc"
+prepare_etc_lower
+`
+	cmd := exec.Command("sh", "-c", script, "sh", sysroot, hook)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("prepare_etc_lower output: %s", string(out))
+	}
+	return err
+}
+
+func countEntries(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", dir, err)
+	}
+	return len(entries)
+}
+
+// newOverlaySandbox creates a fake sysroot with a populated /etc and the
+// overlay upper/work directories, and returns the sysroot path.
+func newOverlaySandbox(t *testing.T) string {
+	t.Helper()
+	sysroot := t.TempDir()
+	etc := filepath.Join(sysroot, "etc")
+	upper := filepath.Join(sysroot, "var", "lib", "nbc", "etc-overlay", "upper")
+	work := filepath.Join(sysroot, "var", "lib", "nbc", "etc-overlay", "work")
+	for _, d := range []string{etc, upper, work} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	// Populate the container's /etc with some default files.
+	for name, content := range map[string]string{
+		"os-release":   "ID=snow\n",
+		"adduser.conf": "DSHELL=/bin/bash\n",
+		"sshd_config":  "PermitRootLogin no\n",
+	} {
+		if err := os.WriteFile(filepath.Join(etc, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return sysroot
+}
+
+// TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper is the regression test
+// for the defeated-/etc-overlay bug (issue #84). When nbc has pre-populated
+// /.etc.lower (Design X), the hook must use it as the lower layer WITHOUT
+// copying the root filesystem's /etc into the writable upper layer. A polluted
+// upper permanently shadows the lower, so container /etc updates would be
+// silently lost on every A/B update.
+func TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper(t *testing.T) {
+	sysroot := newOverlaySandbox(t)
+	etc := filepath.Join(sysroot, "etc")
+	lower := filepath.Join(sysroot, ".etc.lower")
+	upper := filepath.Join(sysroot, "var", "lib", "nbc", "etc-overlay", "upper")
+
+	// Simulate nbc's PopulateEtcLower: .etc.lower is a copy of the container /etc.
+	if err := os.MkdirAll(lower, 0755); err != nil {
+		t.Fatalf("mkdir lower: %v", err)
+	}
+	if out, err := exec.Command("cp", "-a", etc+"/.", lower+"/").CombinedOutput(); err != nil {
+		t.Fatalf("seed .etc.lower: %v: %s", err, out)
+	}
+
+	if got := countEntries(t, upper); got != 0 {
+		t.Fatalf("precondition: upper should start empty, has %d entries", got)
+	}
+
+	if err := runPrepareEtcLower(t, sysroot); err != nil {
+		t.Fatalf("prepare_etc_lower failed: %v", err)
+	}
+
+	// The core assertion: upper must remain empty. On the buggy hook it gets the
+	// entire /etc copied into it.
+	if got := countEntries(t, upper); got != 0 {
+		names, _ := os.ReadDir(upper)
+		var polluted []string
+		for _, n := range names {
+			polluted = append(polluted, n.Name())
+		}
+		t.Errorf("upper layer was polluted with %d entries from /etc: %v", got, polluted)
+	}
+
+	// The populated lower layer must be left intact for use as the overlay lowerdir.
+	if got := countEntries(t, lower); got == 0 {
+		t.Errorf(".etc.lower should remain populated, is empty")
+	}
+}
+
+// TestEtcOverlayHook_EmptyLowerSeedsFromEtc verifies the fallback path: when
+// /.etc.lower is empty/missing, the hook seeds it by moving the root fs /etc,
+// and still leaves upper empty.
+func TestEtcOverlayHook_EmptyLowerSeedsFromEtc(t *testing.T) {
+	sysroot := newOverlaySandbox(t)
+	etc := filepath.Join(sysroot, "etc")
+	lower := filepath.Join(sysroot, ".etc.lower")
+	upper := filepath.Join(sysroot, "var", "lib", "nbc", "etc-overlay", "upper")
+
+	etcEntries := countEntries(t, etc)
+
+	if err := runPrepareEtcLower(t, sysroot); err != nil {
+		t.Fatalf("prepare_etc_lower failed: %v", err)
+	}
+
+	if got := countEntries(t, upper); got != 0 {
+		t.Errorf("upper layer must stay empty, has %d entries", got)
+	}
+	if got := countEntries(t, lower); got != etcEntries {
+		t.Errorf(".etc.lower should have been seeded with %d entries from /etc, has %d", etcEntries, got)
+	}
+}

--- a/tests/tests/02-etc-overlay.sh
+++ b/tests/tests/02-etc-overlay.sh
@@ -36,6 +36,14 @@ check "Overlay work dir exists" \
 check "/.etc.lower exists" \
     test -d /.etc.lower
 
+# Regression guard for issue #84: the overlay upper layer must hold only user
+# modifications, NOT a copy of the container's default /etc. If default files
+# leak into upper they permanently shadow the lower layer and silently defeat
+# /etc updates on every A/B update. os-release ships in every image and is
+# never user-modified, so it must not appear in the upper layer.
+check "Overlay upper is not polluted with container defaults (os-release)" \
+    bash -c '! test -e /var/lib/nbc/etc-overlay/upper/os-release'
+
 # Test persistence: write a file to /etc and verify it's there
 MARKER="/etc/nbc-qemu-test-marker"
 check "Can write to /etc overlay" \


### PR DESCRIPTION
Fixes #84.

## Problem

The `/etc` overlay was silently defeated. On the running snowloaded system the overlay `upper` layer held a **full copy of `/etc`** (237 entries, `adduser.conf` byte-identical to the pristine snapshot) instead of only user modifications. Because overlayfs `upper` shadows `lower` per file, every A/B update that changes a default `/etc` file (sshd_config, sudoers.d, PAM, CA config, …) has **no effect** — the stale first-boot copy always wins. No error is surfaced.

## Root cause

The design (`docs/ETC-OVERLAY.md`, "Design X") is: nbc pre-populates `/.etc.lower` with the container `/etc` as the read-only lower layer, and `upper` holds only user deltas. The dracut hook, however, treated a populated `.etc.lower` **and** a populated root-fs `/etc` as leftover state from a failed attempt and `cp -a`'d all of `/etc` into `upper`. Since nbc always populates `.etc.lower` and the root's `/etc` is always populated, this "merge" branch fired on the first boot of every install/update.

Reproduced deterministically in a sandbox running the hook's exact branch logic: empty `upper` → 2/2 default files copied in.

## Fix

`pkg/dracut/95etc-overlay/etc-overlay-mount.sh`:
- When `/.etc.lower` is already populated, use it as the lower layer **as-is** and mount the overlay without touching `upper`. The container `/etc` on the root fs is simply shadowed by the overlay mount; the identical content comes through the lower layer.
- Only seed the lower layer (by moving `/etc`) when it is empty/missing.
- Extracted the reconciliation into `prepare_etc_lower()` so it is unit-testable in isolation.
- Corrected the mount-failure rollback to only undo a move that actually happened (previously it could `mv .etc.lower` over a still-populated `/etc`).

## Tests

- `pkg/etc_overlay_hook_test.go` — root-free regression tests that source and run the **real** hook logic:
  - `TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper` (fails on the old hook, passes now)
  - `TestEtcOverlayHook_EmptyLowerSeedsFromEtc` (fallback path)
- `tests/tests/02-etc-overlay.sh` — VM assertion that `upper` is not polluted with container defaults (`os-release`).

Verified: `make fmt`, `make build`, `make test-unit`, `make lint` (0 issues), `sh -n` on the hook, shellcheck adds no new warnings, dracut embed intact.

## Migration note (not handled here)

Systems already installed before this fix have a polluted `upper` on `/var`; it persists across updates. Clearing the stale, unmodified entries from `/var/lib/nbc/etc-overlay/upper` is a separate migration step and is intentionally out of scope for this change (deleting from `upper` risks removing genuine user edits and needs its own careful design). The fix ensures new installs — and future updates once a fixed initramfs is in the image — keep `upper` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)