### PR TITLE
fix(bootloader): write boot config files atomically (#87)

### DIFF
--- a/pkg/atomicwrite.go
+++ b/pkg/atomicwrite.go
@@ -1,0 +1,71 @@
+package pkg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to path atomically: it writes to a temporary file
+// in the same directory, fsyncs it, then renames it over the destination and
+// fsyncs the directory. A crash or power loss at any point leaves either the old
+// file fully intact or the new file fully written -- never a truncated or
+// partial file.
+//
+// This matters for boot-critical config files (grub.cfg, loader.conf, and
+// systemd-boot entries) on the ESP: a plain os.WriteFile truncates the
+// destination before writing, so an interruption mid-write can corrupt a config
+// that was valid moments earlier and leave the machine unbootable.
+//
+// The temp file is created in the destination directory so the rename stays on
+// the same filesystem (a cross-filesystem rename is not atomic and would fail).
+// This works on FAT32/vfat ESPs, where rename is a directory-entry update.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+
+	// Clean up the temp file on any error path before the rename succeeds.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("failed to write temp file for %s: %w", path, err)
+	}
+	// Best-effort permission set. These files live on the FAT32 ESP, where
+	// permissions are governed by mount options and fchmod may legitimately
+	// fail; on real filesystems this applies the requested mode. Either way the
+	// file content is what matters for bootability, so a chmod failure must not
+	// abort the atomic write.
+	_ = tmp.Chmod(perm)
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("failed to sync temp file for %s: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file for %s: %w", path, err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to rename temp file into place for %s: %w", path, err)
+	}
+	committed = true
+
+	// fsync the directory so the rename itself is durable. Best-effort: some
+	// filesystems (e.g. certain vfat setups) may not support directory fsync,
+	// and the rename is already the atomic-visibility guarantee.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+
+	return nil
+}

--- a/pkg/atomicwrite_test.go
+++ b/pkg/atomicwrite_test.go
@@ -1,0 +1,124 @@
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAtomicWriteFile_WritesContentAndPerms verifies the happy path: content and
+// permissions land exactly as requested.
+func TestAtomicWriteFile_WritesContentAndPerms(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "grub.cfg")
+	want := []byte("set default=0\n")
+
+	if err := atomicWriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("atomicWriteFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("content = %q, want %q", got, want)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("perm = %o, want 0644", info.Mode().Perm())
+	}
+}
+
+// TestAtomicWriteFile_OverwritesExisting verifies an existing file is replaced
+// with the new content.
+func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "loader.conf")
+	if err := os.WriteFile(path, []byte("old content that is longer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []byte("new")
+	if err := atomicWriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("atomicWriteFile failed: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("content = %q, want %q (truncation/overwrite failed)", got, want)
+	}
+}
+
+// TestAtomicWriteFile_NoTempLitterOnSuccess verifies the temporary file used for
+// the atomic rename is not left behind.
+func TestAtomicWriteFile_NoTempLitterOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bootc.conf")
+
+	if err := atomicWriteFile(path, []byte("title Snow\n"), 0o644); err != nil {
+		t.Fatalf("atomicWriteFile failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected only the destination file, found %d entries: %v", len(entries), names)
+	}
+}
+
+// TestAtomicWriteFile_PreservesExistingOnFailure is the core guarantee behind the
+// fix: if the write cannot complete, the pre-existing file must NOT be left
+// truncated or corrupt. A naive os.WriteFile truncates the destination before
+// writing, so a mid-write crash destroys the previously-valid file (which, for
+// grub.cfg holding both A/B entries, bricks the machine).
+//
+// We simulate an un-completable write by pointing at a path whose parent
+// directory has been made read-only, so creating the temp file fails.
+func TestAtomicWriteFile_PreservesExistingOnFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("read-only directory permissions are not enforced for root")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "grub.cfg")
+	original := []byte("GOOD original config with both A/B entries\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory read-only so temp-file creation (and thus the write)
+	// fails without touching the existing destination.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if err := atomicWriteFile(path, []byte("new content"), 0o644); err == nil {
+		t.Fatal("expected atomicWriteFile to fail when the directory is read-only")
+	}
+
+	// Restore access to read the file back.
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("existing file was corrupted on failed write: got %q, want %q", got, original)
+	}
+}

--- a/pkg/bootloader.go
+++ b/pkg/bootloader.go
@@ -528,7 +528,7 @@ menuentry '%s' {
 	}
 
 	grubCfgPath := filepath.Join(grubDir, "grub.cfg")
-	if err := os.WriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
+	if err := atomicWriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
 		return fmt.Errorf("failed to write grub.cfg: %w", err)
 	}
 
@@ -699,7 +699,7 @@ console-mode max
 editor yes
 `
 	loaderConfPath := filepath.Join(loaderDir, "loader.conf")
-	if err := os.WriteFile(loaderConfPath, []byte(loaderConf), 0644); err != nil {
+	if err := atomicWriteFile(loaderConfPath, []byte(loaderConf), 0644); err != nil {
 		return fmt.Errorf("failed to write loader.conf: %w", err)
 	}
 
@@ -721,7 +721,7 @@ options %s
 `, b.OSName, kernelVersion, initrd, strings.Join(kernelCmdline, " "))
 
 	entryPath := filepath.Join(entriesDir, "bootc.conf")
-	if err := os.WriteFile(entryPath, []byte(entry), 0644); err != nil {
+	if err := atomicWriteFile(entryPath, []byte(entry), 0644); err != nil {
 		return fmt.Errorf("failed to write boot entry: %w", err)
 	}
 

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1277,7 +1277,7 @@ func (u *SystemUpdater) updateGRUBBootloader() error {
 	grubCfg := buildGRUBConfig(osName, kernelVersion, initrd, kernelCmdline, previousKernelVersion, previousInitrd, previousCmdline)
 
 	grubCfgPath := filepath.Join(grubDir, "grub.cfg")
-	if err := os.WriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
+	if err := atomicWriteFile(grubCfgPath, []byte(grubCfg), 0644); err != nil {
 		return fmt.Errorf("failed to write grub.cfg: %w", err)
 	}
 
@@ -1367,7 +1367,7 @@ func (u *SystemUpdater) updateSystemdBootBootloader() error {
 	mainEntry := buildSystemdBootEntry(osName, kernelVersion, initrd, kernelCmdline)
 
 	mainEntryPath := filepath.Join(entriesDir, "bootc.conf")
-	if err := os.WriteFile(mainEntryPath, []byte(mainEntry), 0644); err != nil {
+	if err := atomicWriteFile(mainEntryPath, []byte(mainEntry), 0644); err != nil {
 		return fmt.Errorf("failed to write main boot entry: %w", err)
 	}
 
@@ -1393,7 +1393,7 @@ func (u *SystemUpdater) updateSystemdBootBootloader() error {
 	previousEntry := buildSystemdBootEntry(osName+" (Previous)", previousKernelVersion, previousInitrd, previousCmdline)
 
 	previousEntryPath := filepath.Join(entriesDir, "bootc-previous.conf")
-	if err := os.WriteFile(previousEntryPath, []byte(previousEntry), 0644); err != nil {
+	if err := atomicWriteFile(previousEntryPath, []byte(previousEntry), 0644); err != nil {
 		return fmt.Errorf("failed to write rollback boot entry: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #87.

## Problem

`grub.cfg`, `loader.conf`, and the systemd-boot entry files (`bootc.conf`, `bootc-previous.conf`) were written with `os.WriteFile`, which **truncates the destination before writing**. A crash or power loss mid-write corrupts a config that was valid moments earlier.

For `grub.cfg` this is critical (#87): GRUB2 keeps **both** the current entry and the "previous" rollback entry in that single file, so a torn write leaves the machine unbootable at the bootloader level even though a fully-intact root filesystem still exists on disk — defeating the whole point of A/B rollback.

## Fix

Add `atomicWriteFile` (`pkg/atomicwrite.go`): write to a temp file in the same directory → `fsync` → `rename` over the destination → `fsync` the directory. A power loss now leaves either the old file fully intact or the new file fully written, never a partial one. Wired into all six boot-config writes across the install (`bootloader.go`) and update (`update.go`) flows.

Design notes:
- **Same-dir temp** so the rename stays on one filesystem (cross-fs rename isn't atomic).
- **Best-effort chmod**: these files live on the FAT32 ESP, where `fchmod` is governed by mount options and can fail. The original `os.WriteFile` passed the mode to `open()` (which vfat ignores), so hard-failing on chmod would be a regression. On real filesystems the mode is applied.
- **Temp name is a dotfile not ending in `.conf`** (`.bootc.conf.tmp-XXXX`), so neither systemd-boot (`entries/*.conf`) nor GRUB ever parses a partial temp file, and it's cleaned up on error paths.

## Tests

`pkg/atomicwrite_test.go`:
- `TestAtomicWriteFile_WritesContentAndPerms`
- `TestAtomicWriteFile_OverwritesExisting`
- `TestAtomicWriteFile_NoTempLitterOnSuccess`
- `TestAtomicWriteFile_PreservesExistingOnFailure` — the core guarantee: a failed write leaves the pre-existing file **uncorrupted** (fails on a naive truncating write)

Also validated end-to-end against a **real FAT32 loopback mount** as root (write + overwrite + no temp litter), since the ESP is the actual target filesystem. Full gate green: `make fmt`, `build`, `test-unit`, `lint` (0 issues), `go vet`.

## Scope

This also covers the atomicity/fsync half of #25. The separate concern in #25 — the install-time systemd-boot generator deleting all `entries/*.conf` before writing the new one (a brief zero-entry window) — is **not** changed here and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)