### PR TITLE
fix(update): harden LUKS unlock — no-echo passphrase, no var mapping leak (#90, #91)

### DIFF
--- a/pkg/passphrase.go
+++ b/pkg/passphrase.go
@@ -43,8 +43,13 @@ func readPassphrase(prompt string) (string, error) {
 // preserved. A final line with no newline (EOF) is returned as-is.
 func readPassphraseLine(r io.Reader) (string, error) {
 	line, err := bufio.NewReader(r).ReadString('\n')
-	if err != nil && err != io.EOF {
-		return "", err
+	if err != nil {
+		if err == io.EOF && line == "" {
+			return "", io.EOF
+		}
+		if err != io.EOF {
+			return "", err
+		}
 	}
 	return strings.TrimRight(line, "\r\n"), nil
 }

--- a/pkg/passphrase.go
+++ b/pkg/passphrase.go
@@ -1,0 +1,50 @@
+package pkg
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// readPassphrase prompts the user and reads a single-line secret.
+//
+// When stdin is a terminal, the input is read without echoing it, so the
+// passphrase is not exposed in the terminal or its scrollback. When stdin is not
+// a terminal (e.g. piped input in automation), a full line is read from stdin.
+//
+// Unlike fmt.Scanln, the ENTIRE line is returned, so passphrases containing
+// spaces (e.g. a diceware phrase) are preserved rather than truncated at the
+// first space.
+func readPassphrase(prompt string) (string, error) {
+	// Prompt on stderr so it never contaminates stdout (e.g. JSON output).
+	fmt.Fprint(os.Stderr, prompt)
+
+	fd := int(os.Stdin.Fd())
+	if term.IsTerminal(fd) {
+		b, err := term.ReadPassword(fd)
+		// ReadPassword consumes the newline but does not echo one; emit it so
+		// subsequent output starts on a fresh line.
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	return readPassphraseLine(os.Stdin)
+}
+
+// readPassphraseLine reads one line from r and returns it with the trailing
+// line terminator (\n or \r\n) removed. Interior and leading/trailing spaces are
+// preserved. A final line with no newline (EOF) is returned as-is.
+func readPassphraseLine(r io.Reader) (string, error) {
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}

--- a/pkg/passphrase_test.go
+++ b/pkg/passphrase_test.go
@@ -1,0 +1,49 @@
+package pkg
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReadPassphraseLine_PreservesSpaces is the regression test for #91: the
+// previous fmt.Scanln read stops at the first whitespace, silently truncating a
+// passphrase that contains spaces (e.g. a diceware phrase). readPassphraseLine
+// must return the entire line.
+func TestReadPassphraseLine_PreservesSpaces(t *testing.T) {
+	got, err := readPassphraseLine(strings.NewReader("correct horse battery staple\n"))
+	if err != nil {
+		t.Fatalf("readPassphraseLine error: %v", err)
+	}
+	if want := "correct horse battery staple"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadPassphraseLine_StripsTrailingNewlineAndCR(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"secret\n", "secret"},
+		{"secret\r\n", "secret"},
+		{"secret", "secret"}, // no trailing newline (EOF)
+		{"with  double  spaces\n", "with  double  spaces"},
+	} {
+		got, err := readPassphraseLine(strings.NewReader(tc.in))
+		if err != nil {
+			t.Fatalf("input %q: unexpected error %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("input %q: got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestReadPassphraseLine_DoesNotStripInteriorOrLeadingSpaces ensures we only
+// trim the line terminator, not meaningful passphrase characters.
+func TestReadPassphraseLine_DoesNotStripInteriorOrLeadingSpaces(t *testing.T) {
+	got, err := readPassphraseLine(strings.NewReader("  leading and trailing kept \n"))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if want := "  leading and trailing kept "; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -597,9 +597,7 @@ func (u *SystemUpdater) Update() error {
 
 			// Fall back to passphrase if TPM2 not enabled or failed
 			if !opened {
-				fmt.Print("Enter LUKS passphrase: ")
-				var passphrase string
-				_, err := fmt.Scanln(&passphrase)
+				passphrase, err := readPassphrase("Enter LUKS passphrase: ")
 				if err != nil {
 					return fmt.Errorf("failed to read passphrase: %w", err)
 				}
@@ -675,7 +673,6 @@ func (u *SystemUpdater) Update() error {
 	// The var partition is shared between A/B roots - same partition mounted at /var on running system
 	varMountPoint := filepath.Join(u.Config.MountPoint, "var")
 	varDevice := u.Scheme.VarPartition
-	varLUKSOpened := false // Track if we opened var LUKS (need to close it on cleanup)
 
 	// For encrypted systems, open var LUKS container if not already open
 	if u.Encryption != nil && u.Encryption.Enabled {
@@ -707,9 +704,7 @@ func (u *SystemUpdater) Update() error {
 
 			// Fall back to passphrase if TPM2 not enabled or failed
 			if !opened {
-				fmt.Print("Enter LUKS passphrase for var partition: ")
-				var passphrase string
-				_, err := fmt.Scanln(&passphrase)
+				passphrase, err := readPassphrase("Enter LUKS passphrase for var partition: ")
 				if err != nil {
 					return fmt.Errorf("failed to read passphrase: %w", err)
 				}
@@ -719,7 +714,13 @@ func (u *SystemUpdater) Update() error {
 					return fmt.Errorf("failed to open var LUKS container: %w", err)
 				}
 			}
-			varLUKSOpened = true
+
+			// Register the LUKS-close cleanup immediately after opening, BEFORE
+			// the mount below. Otherwise a mount failure returns before this
+			// defer is registered and leaks the /dev/mapper/var dm-crypt mapping.
+			defer func() {
+				_ = CloseLUKS(context.Background(), "var", nil)
+			}()
 		} else {
 			p.Message("Var LUKS container already open at %s", varMapperPath)
 		}
@@ -733,10 +734,6 @@ func (u *SystemUpdater) Update() error {
 	}
 	defer func() {
 		_ = exec.Command("umount", varMountPoint).Run()
-		// Close var LUKS if we opened it
-		if varLUKSOpened {
-			_ = CloseLUKS(context.Background(), "var", nil)
-		}
 	}()
 
 	// Step 5: Setup target system (dracut, directories, machine-id, etc.lower, tmpfiles)


### PR DESCRIPTION
Fixes #91 and #90 — two High-severity issues in the update-path LUKS unlock (same function, same subsystem).

## #91 — passphrase read with `fmt.Scanln`
`fmt.Scanln` stops at the first whitespace, so a passphrase containing spaces (e.g. a diceware phrase) was **silently truncated** — the user typed the right phrase, unlock failed with a generic error, and there was no hint the input was cut. It also **echoed the secret** to the terminal/scrollback.

Added `readPassphrase`, which:
- reads the whole line **without echo** when stdin is a TTY (`term.ReadPassword`),
- falls back to a full-line read for piped/automation input (still preserving spaces),
- prompts on **stderr** so it never contaminates stdout/JSON.

Applied to both the root and var passphrase prompts. The yes/no update confirmation (`fmt.Scanln(&response)`) is intentionally unchanged.

## #90 — leaked `/dev/mapper/var` on mount failure
The var LUKS close cleanup was deferred **after** the var `mount` call, so a mount failure returned before the defer was registered and left the dm-crypt mapping open — blocking clean recovery and re-runs. The close defer is now registered immediately after opening the container, **before** the mount, mirroring the already-correct root-partition path. The "already open" branch still does not close a mapping the running system depends on. The redundant `varLUKSOpened` flag is removed.

## Tests
`pkg/passphrase_test.go` covers the core #91 regression: `readPassphraseLine` preserves interior/leading/trailing spaces and trims only the line terminator (`\n`/`\r\n`), including the no-trailing-newline (EOF) case. The no-echo TTY path needs a PTY so it isn't unit-tested, but the space-truncation bug lives entirely in the line reader, which is.

Verified: `make fmt`, `build`, `test-unit`, `lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)