### PR TITLE
fix(bootloader): do not install fbx64.efi on GRUB2 Secure Boot path (#89)

### DIFF
--- a/pkg/bootloader.go
+++ b/pkg/bootloader.go
@@ -895,22 +895,11 @@ func (b *BootloaderInstaller) setupSecureBootChain(bootloaderEFI string) (bool, 
 		}
 	}
 
-	// Also copy fbx64.efi (fallback) if available
-	fbPaths := []string{
-		filepath.Join(b.TargetDir, "boot", "efi", "EFI", "fedora", "fbx64.efi"),
-		filepath.Join(b.TargetDir, "boot", "efi", "EFI", "BOOT", "fbx64.efi"),
-		filepath.Join(b.TargetDir, "usr", "lib", "shim", "fbx64.efi"),
-		filepath.Join(b.TargetDir, "usr", "lib64", "shim", "fbx64.efi"),
-	}
-	for _, fbPath := range fbPaths {
-		if _, err := os.Stat(fbPath); err == nil {
-			fbDest := filepath.Join(efiBootDir, "fbx64.efi")
-			if err := copyEFIFile(fbPath, fbDest); err == nil {
-				b.Progress.Message("Installed fallback bootloader (fbx64.efi)")
-			}
-			break
-		}
-	}
+	// NOTE: We intentionally do NOT install fbx64.efi (fallback bootloader),
+	// matching the systemd-boot path. fbx64.efi looks for EFI/<distro>/BOOTX64.CSV
+	// to restore boot entries, but our layout uses EFI/BOOT/ directly and never
+	// writes a BOOTX64.CSV, so the fallback loader fails with a "Restore Boot
+	// Option" blue screen. (See CLAUDE.md: "Do NOT include fbx64.efi".)
 
 	return true, nil
 }

--- a/pkg/bootloader_securebooot_test.go
+++ b/pkg/bootloader_securebooot_test.go
@@ -1,0 +1,61 @@
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frostyard/std/reporter"
+)
+
+// TestSetupSecureBootChain_GRUB2_DoesNotInstallFbx64 is the regression test for
+// #89. On the GRUB2 Secure Boot path, fbx64.efi must NOT be installed: like the
+// systemd-boot path, our layout uses EFI/BOOT/ directly with no BOOTX64.CSV, so
+// the fallback loader triggers a "Restore Boot Option" blue screen. CLAUDE.md
+// also states explicitly: do NOT include fbx64.efi.
+func TestSetupSecureBootChain_GRUB2_DoesNotInstallFbx64(t *testing.T) {
+	targetDir := t.TempDir()
+
+	// Lay out a container rootfs with the binaries the GRUB2 chain looks for.
+	writeFile := func(rel string) {
+		p := filepath.Join(targetDir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("EFI-BINARY:"+rel), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(filepath.Join("usr", "lib", "shim", "shimx64.efi.signed"))                    // findShimEFI
+	writeFile(filepath.Join("usr", "lib", "grub", "x86_64-efi-signed", "grubx64.efi.signed")) // findSignedGrubEFI
+	writeFile(filepath.Join("usr", "lib", "shim", "mmx64.efi"))                             // findMokManager
+	writeFile(filepath.Join("usr", "lib", "shim", "fbx64.efi"))                             // fallback loader (must be ignored)
+
+	b := &BootloaderInstaller{
+		Type:      BootloaderGRUB2,
+		TargetDir: targetDir,
+		Progress:  reporter.NoopReporter{},
+	}
+
+	ok, err := b.setupSecureBootChain(filepath.Join(targetDir, "unused-grub.efi"))
+	if err != nil {
+		t.Fatalf("setupSecureBootChain: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected Secure Boot chain to be set up (shim present)")
+	}
+
+	efiBootDir := filepath.Join(targetDir, "boot", "EFI", "BOOT")
+
+	// The chain itself must be present.
+	for _, name := range []string{"BOOTX64.EFI", "grubx64.efi"} {
+		if _, err := os.Stat(filepath.Join(efiBootDir, name)); err != nil {
+			t.Errorf("expected %s to be installed: %v", name, err)
+		}
+	}
+
+	// fbx64.efi must NOT be present.
+	if _, err := os.Stat(filepath.Join(efiBootDir, "fbx64.efi")); !os.IsNotExist(err) {
+		t.Errorf("fbx64.efi must not be installed on the GRUB2 Secure Boot path (causes Restore Boot Option blue screen)")
+	}
+}

--- a/pkg/bootloader_securebooot_test.go
+++ b/pkg/bootloader_securebooot_test.go
@@ -26,10 +26,10 @@ func TestSetupSecureBootChain_GRUB2_DoesNotInstallFbx64(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	writeFile(filepath.Join("usr", "lib", "shim", "shimx64.efi.signed"))                    // findShimEFI
+	writeFile(filepath.Join("usr", "lib", "shim", "shimx64.efi.signed"))                      // findShimEFI
 	writeFile(filepath.Join("usr", "lib", "grub", "x86_64-efi-signed", "grubx64.efi.signed")) // findSignedGrubEFI
-	writeFile(filepath.Join("usr", "lib", "shim", "mmx64.efi"))                             // findMokManager
-	writeFile(filepath.Join("usr", "lib", "shim", "fbx64.efi"))                             // fallback loader (must be ignored)
+	writeFile(filepath.Join("usr", "lib", "shim", "mmx64.efi"))                               // findMokManager
+	writeFile(filepath.Join("usr", "lib", "shim", "fbx64.efi"))                               // fallback loader (must be ignored)
 
 	b := &BootloaderInstaller{
 		Type:      BootloaderGRUB2,


### PR DESCRIPTION
Fixes #89.

## Problem
The GRUB2 Secure Boot path copied `fbx64.efi` into `EFI/BOOT/`. The systemd-boot path deliberately does **not** — and documents why: `fbx64.efi` looks for `EFI/<distro>/BOOTX64.CSV` to restore boot entries, but our layout uses `EFI/BOOT/` directly and never writes a `BOOTX64.CSV`, so on firmware that invokes the fallback loader it fails with a **"Restore Boot Option" blue screen** and the machine won't boot. CLAUDE.md states the rule explicitly: *"Do NOT include fbx64.efi."* The GRUB2 path violated it.

## Fix
Remove the `fbx64.efi` copy block from the GRUB2 Secure Boot path so it matches the systemd-boot behavior. The shim → `BOOTX64.EFI` and signed-grub → `grubx64.efi` chain is unchanged.

## Test
`TestSetupSecureBootChain_GRUB2_DoesNotInstallFbx64` lays out a rootfs containing shim, signed grub, MOK manager, and `fbx64.efi`, runs the GRUB2 chain setup, and asserts `BOOTX64.EFI` + `grubx64.efi` are installed while `fbx64.efi` is not. It fails before this change.

Verified: `make fmt`, `build`, `test-unit`, `lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)