### PR TITLE
fix(partition): roll back partial mounts in MountPartitions (#92)

### DIFF
--- a/pkg/partition.go
+++ b/pkg/partition.go
@@ -382,12 +382,15 @@ func MountPartitions(ctx context.Context, scheme *PartitionScheme, mountPoint st
 	// on the busy mountpoint.
 	var mounted []string
 	success := false
+	rollbackCtx := context.WithoutCancel(ctx)
 	defer func() {
 		if success {
 			return
 		}
 		for i := len(mounted) - 1; i >= 0; i-- {
-			_ = umountCommand(ctx, mounted[i])
+			if err := umountCommand(rollbackCtx, mounted[i]); err != nil {
+				progress.Warning("failed to rollback unmount %s: %v", mounted[i], err)
+			}
 		}
 	}()
 

--- a/pkg/partition.go
+++ b/pkg/partition.go
@@ -338,6 +338,22 @@ func formatPartition(ctx context.Context, partition, fsType, label string) error
 }
 
 // MountPartitions mounts the partitions to a temporary directory
+// mountCommand and umountCommand wrap the mount/umount syscalls used during
+// partition setup. They are variables so the rollback path can be exercised in
+// tests without root or real block devices.
+var (
+	mountCommand = func(ctx context.Context, device, target string) error {
+		cmd := exec.CommandContext(ctx, "mount", device, target)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%w\nOutput: %s", err, string(output))
+		}
+		return nil
+	}
+	umountCommand = func(ctx context.Context, target string) error {
+		return exec.CommandContext(ctx, "umount", target).Run()
+	}
+)
+
 func MountPartitions(ctx context.Context, scheme *PartitionScheme, mountPoint string, dryRun bool, progress reporter.Reporter) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -359,11 +375,27 @@ func MountPartitions(ctx context.Context, scheme *PartitionScheme, mountPoint st
 	root1Dev := scheme.GetRoot1Device()
 	varDev := scheme.GetVarDevice()
 
+	// Track partitions we have mounted so a partial failure can be rolled back.
+	// Without this, a failure partway through leaves earlier mounts in place,
+	// and the caller only registers its unmount cleanup after MountPartitions
+	// returns successfully -- so the leaked mounts would block a retried install
+	// on the busy mountpoint.
+	var mounted []string
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		for i := len(mounted) - 1; i >= 0; i-- {
+			_ = umountCommand(ctx, mounted[i])
+		}
+	}()
+
 	// Mount first root partition (or LUKS mapper device)
-	cmd := exec.CommandContext(ctx, "mount", root1Dev, mountPoint)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to mount root1 partition: %w\nOutput: %s", err, string(output))
+	if err := mountCommand(ctx, root1Dev, mountPoint); err != nil {
+		return fmt.Errorf("failed to mount root1 partition: %w", err)
 	}
+	mounted = append(mounted, mountPoint)
 
 	// Create boot and var subdirectories
 	bootDir := filepath.Join(mountPoint, "boot")
@@ -376,17 +408,18 @@ func MountPartitions(ctx context.Context, scheme *PartitionScheme, mountPoint st
 	}
 
 	// Mount boot partition (FAT32 EFI System Partition - never encrypted)
-	cmd = exec.CommandContext(ctx, "mount", scheme.BootPartition, bootDir)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to mount boot partition: %w\nOutput: %s", err, string(output))
+	if err := mountCommand(ctx, scheme.BootPartition, bootDir); err != nil {
+		return fmt.Errorf("failed to mount boot partition: %w", err)
 	}
+	mounted = append(mounted, bootDir)
 
 	// Mount /var partition (or LUKS mapper device)
-	cmd = exec.CommandContext(ctx, "mount", varDev, varDir)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to mount var partition: %w\nOutput: %s", err, string(output))
+	if err := mountCommand(ctx, varDev, varDir); err != nil {
+		return fmt.Errorf("failed to mount var partition: %w", err)
 	}
+	mounted = append(mounted, varDir)
 
+	success = true
 	progress.MessagePlain("Partitions mounted successfully")
 	return nil
 }

--- a/pkg/partition_rollback_test.go
+++ b/pkg/partition_rollback_test.go
@@ -1,0 +1,56 @@
+package pkg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/std/reporter"
+)
+
+// TestMountPartitions_RollsBackOnPartialFailure is the regression test for #92.
+// If a later mount fails (e.g. the boot partition), the partitions already
+// mounted (root1) must be unmounted before returning, so a partial failure does
+// not leak mounts and block a retried install on the busy mountpoint.
+func TestMountPartitions_RollsBackOnPartialFailure(t *testing.T) {
+	var mounted []string
+	var unmounted []string
+
+	origMount, origUmount := mountCommand, umountCommand
+	t.Cleanup(func() { mountCommand, umountCommand = origMount, origUmount })
+
+	mountCommand = func(_ context.Context, _, target string) error {
+		// Simulate the boot partition mount failing after root1 succeeds.
+		if strings.HasSuffix(target, "/boot") {
+			return &mountError{}
+		}
+		mounted = append(mounted, target)
+		return nil
+	}
+	umountCommand = func(_ context.Context, target string) error {
+		unmounted = append(unmounted, target)
+		return nil
+	}
+
+	scheme := &PartitionScheme{
+		BootPartition:  "/dev/fake-boot",
+		Root1Partition: "/dev/fake-root1",
+		VarPartition:   "/dev/fake-var",
+	}
+	mountPoint := t.TempDir()
+
+	err := MountPartitions(context.Background(), scheme, mountPoint, false, reporter.NoopReporter{})
+	if err == nil {
+		t.Fatal("expected an error when the boot mount fails")
+	}
+
+	// root1 was mounted at mountPoint and must be rolled back; boot failed (not
+	// mounted); var was never attempted.
+	if len(unmounted) != 1 || unmounted[0] != mountPoint {
+		t.Errorf("expected rollback to unmount %q exactly once, got: %v", mountPoint, unmounted)
+	}
+}
+
+type mountError struct{}
+
+func (mountError) Error() string { return "simulated mount failure" }


### PR DESCRIPTION
Fixes #92.

## Problem
`MountPartitions` mounts root1 → boot → var sequentially with no cleanup on failure. If a later mount fails (e.g. a udev-not-settled race on the boot partition), the already-mounted partitions are left mounted and the function returns an error. The install caller (`install.go`) only registers its `UnmountPartitions` cleanup **after** `MountPartitions` returns successfully — so the leaked mount persists, and a retried `nbc install` fails on the busy mountpoint until a manual `umount`.

## Fix
Track partitions as they are mounted and unmount them in reverse order via a deferred rollback that runs unless the function completes successfully. The mount/umount invocations are moved behind `mountCommand`/`umountCommand` function seams so the rollback path can be exercised without root or real block devices.

Error messages still include the mount command output (now wrapped by `mountCommand`).

## Test
`TestMountPartitions_RollsBackOnPartialFailure` overrides the seams to fail the boot mount after root1 succeeds and asserts root1 (the mountpoint) is unmounted exactly once. Verified it fails with the rollback removed and passes with it. The existing root-only `TestMountPartitions` still covers the happy path.

Verified: `make fmt`, `build`, `test-unit`, `lint` (0 issues), `go vet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)