### PR TITLE
chore: make local and CI formatting gates agree (single gofmt source of truth)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,7 @@ jobs:
         run: go vet ./...
 
       - name: Check formatting
-        run: |
-          gofmt -l .
-          test -z "$(gofmt -l .)"
+        run: make fmt-check
 
   docker:
     name: Docker Build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean install test run help
+.PHONY: build clean install test run help fmt fmt-check lint
 
 BINARY_NAME=nbc
 VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -118,9 +118,19 @@ _test-coverage: ## Internal target for coverage tests
 	@go tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
-fmt: ## Format code
+fmt: ## Format code (gofmt -w, matches the CI formatting gate)
 	@echo "Formatting code..."
-	@go fmt ./...
+	@gofmt -w .
+
+fmt-check: ## Check formatting without modifying files (same command CI runs)
+	@echo "Checking formatting..."
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not gofmt-formatted:"; \
+		echo "$$unformatted"; \
+		echo "Run 'make fmt' to fix."; \
+		exit 1; \
+	fi
 
 lint: ## Run linter
 	@echo "Running linter..."


### PR DESCRIPTION
## Problem
The formatting gates could disagree between local and CI, which is how #118's `Verify` job failed on a file that passed locally:

- **CI** checked formatting with `gofmt -l .` — a *checker* that fails the build.
- **Local** `make fmt` ran `go fmt ./...` — a *fixer* that silently rewrites files.

There was no local *check*, so if you forgot to run `make fmt` (or your editor's formatter disagreed with `gofmt` on something like comment-column alignment), it passed locally and only surfaced in CI.

## Fix — one gofmt, one source of truth
Standardize on `gofmt` and have both sides run the same command:

- `make fmt` → `gofmt -w .` (same tool and recursive scope as CI).
- **new** `make fmt-check` → `gofmt -l .`, fails with a clear message listing unformatted files.
- CI's "Check formatting" step now runs **`make fmt-check`** instead of an inline `gofmt` snippet, so the Makefile is the single source of truth and the two gates can't drift.

Developer flow: `make fmt-check` to verify (same as CI), `make fmt` to fix.

## Verification
- `make fmt-check` passes on the clean tree.
- On a deliberately misformatted file it fails with exit ≠ 0 and prints the offending file + `Run 'make fmt' to fix.` (confirmed locally).
- `make fmt` fixes it and `make fmt-check` then passes.

No source files reformatted — main is already gofmt-clean; this only changes the Makefile and the CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)