### PR TITLE
fix(config): atomic writes + corrupt-primary fallback for system config (#93)

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -122,8 +123,9 @@ func WriteSystemConfig(ctx context.Context, config *SystemConfig, dryRun bool, p
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Write to file (0644 = rw-r--r-- = world-readable, root-writable)
-	if err := os.WriteFile(SystemConfigFile, data, 0644); err != nil {
+	// Write atomically (temp file + rename) so a crash mid-write cannot corrupt
+	// the shared A/B config that status/update/download depend on.
+	if err := atomicWriteFile(SystemConfigFile, data, 0644); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
@@ -169,31 +171,47 @@ func cleanupLegacyConfig() {
 }
 
 // ReadSystemConfig reads system configuration from /var/lib/nbc/state/config.json
-// Falls back to legacy location /etc/nbc/config.json for older installations
+// Falls back to legacy location /etc/nbc/config.json for older installations, or
+// if the primary config exists but is corrupt/unparseable.
 func ReadSystemConfig() (*SystemConfig, error) {
-	// Try new location first
-	data, err := os.ReadFile(SystemConfigFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// Try legacy location for older installations
-			data, err = os.ReadFile(LegacySystemConfigFile)
-			if err != nil {
-				if os.IsNotExist(err) {
-					return nil, fmt.Errorf("system configuration not found at %s or %s (system may not be installed with nbc)", SystemConfigFile, LegacySystemConfigFile)
-				}
-				return nil, fmt.Errorf("failed to read legacy config file: %w", err)
-			}
-			// Successfully read from legacy location - config will be migrated on next write
-		} else {
-			return nil, fmt.Errorf("failed to read config file: %w", err)
-		}
+	return loadSystemConfig(SystemConfigFile, LegacySystemConfigFile)
+}
+
+// loadSystemConfig loads config from primaryPath, falling back to legacyPath if
+// the primary is missing OR present-but-unparseable (e.g. a torn/corrupt write).
+// This avoids a hard failure of status/update/download when the shared config is
+// damaged but a valid legacy copy still exists.
+func loadSystemConfig(primaryPath, legacyPath string) (*SystemConfig, error) {
+	config, primaryErr := readAndParseConfig(primaryPath)
+	if primaryErr == nil {
+		return config, nil
 	}
 
+	// Primary missing or corrupt: try the legacy location.
+	legacyConfig, legacyErr := readAndParseConfig(legacyPath)
+	if legacyErr == nil {
+		return legacyConfig, nil
+	}
+
+	// Neither is usable. If both are simply absent, report "not installed";
+	// otherwise surface the primary error (corruption should not be masked).
+	if errors.Is(primaryErr, os.ErrNotExist) && errors.Is(legacyErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("system configuration not found at %s or %s (system may not be installed with nbc)", primaryPath, legacyPath)
+	}
+	return nil, fmt.Errorf("failed to load system configuration from %s: %w", primaryPath, primaryErr)
+}
+
+// readAndParseConfig reads and unmarshals a single config file. A missing file
+// returns an error that satisfies errors.Is(err, os.ErrNotExist).
+func readAndParseConfig(path string) (*SystemConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
 	var config SystemConfig
 	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
+		return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
 	}
-
 	return &config, nil
 }
 
@@ -221,8 +239,9 @@ func WriteSystemConfigToVar(ctx context.Context, varMountPoint string, config *S
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	// Write to file (0644 = rw-r--r-- = world-readable, root-writable)
-	if err := os.WriteFile(configFile, data, 0644); err != nil {
+	// Write atomically (temp file + rename) so a crash mid-write cannot corrupt
+	// the shared A/B config that status/update/download depend on.
+	if err := atomicWriteFile(configFile, data, 0644); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 

--- a/pkg/config_fallback_test.go
+++ b/pkg/config_fallback_test.go
@@ -1,0 +1,114 @@
+package pkg
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/frostyard/std/reporter"
+)
+
+func writeJSON(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLoadSystemConfig_FallsBackToLegacyOnCorruptPrimary is the core #93
+// regression: when the primary config exists but is unparseable (e.g. a
+// truncated/corrupt file), ReadSystemConfig previously hard-failed with a parse
+// error. It should fall back to the legacy config if that one is valid.
+func TestLoadSystemConfig_FallsBackToLegacyOnCorruptPrimary(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "config.json")
+	legacy := filepath.Join(dir, "legacy.json")
+	writeJSON(t, primary, "{ this is not valid json")
+	writeJSON(t, legacy, `{"image_ref":"legacy-ref"}`)
+
+	cfg, err := loadSystemConfig(primary, legacy)
+	if err != nil {
+		t.Fatalf("expected fallback to legacy, got error: %v", err)
+	}
+	if cfg.ImageRef != "legacy-ref" {
+		t.Errorf("ImageRef = %q, want %q", cfg.ImageRef, "legacy-ref")
+	}
+}
+
+func TestLoadSystemConfig_PrefersValidPrimary(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "config.json")
+	legacy := filepath.Join(dir, "legacy.json")
+	writeJSON(t, primary, `{"image_ref":"primary-ref"}`)
+	writeJSON(t, legacy, `{"image_ref":"legacy-ref"}`)
+
+	cfg, err := loadSystemConfig(primary, legacy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ImageRef != "primary-ref" {
+		t.Errorf("ImageRef = %q, want %q", cfg.ImageRef, "primary-ref")
+	}
+}
+
+func TestLoadSystemConfig_FallsBackWhenPrimaryMissing(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "config.json") // does not exist
+	legacy := filepath.Join(dir, "legacy.json")
+	writeJSON(t, legacy, `{"image_ref":"legacy-ref"}`)
+
+	cfg, err := loadSystemConfig(primary, legacy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ImageRef != "legacy-ref" {
+		t.Errorf("ImageRef = %q, want %q", cfg.ImageRef, "legacy-ref")
+	}
+}
+
+func TestLoadSystemConfig_NotFoundWhenBothMissing(t *testing.T) {
+	dir := t.TempDir()
+	_, err := loadSystemConfig(filepath.Join(dir, "a.json"), filepath.Join(dir, "b.json"))
+	if err == nil {
+		t.Fatal("expected an error when neither config exists")
+	}
+}
+
+func TestLoadSystemConfig_SurfacesErrorWhenPrimaryCorruptAndNoLegacy(t *testing.T) {
+	dir := t.TempDir()
+	primary := filepath.Join(dir, "config.json")
+	writeJSON(t, primary, "{ corrupt")
+
+	_, err := loadSystemConfig(primary, filepath.Join(dir, "missing.json"))
+	if err == nil {
+		t.Fatal("expected an error when primary is corrupt and legacy is missing")
+	}
+	// The corruption error should not be masked as a bare not-found.
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("error should reflect the corrupt primary, not a not-exist: %v", err)
+	}
+}
+
+// TestWriteSystemConfigToVar_IsAtomic verifies the config write leaves no temp
+// litter and produces a parseable file (the write now goes through
+// atomicWriteFile so a torn write cannot corrupt the shared A/B config).
+func TestWriteSystemConfigToVar_IsAtomic(t *testing.T) {
+	varMount := t.TempDir()
+	cfg := &SystemConfig{ImageRef: "ghcr.io/x/y:latest", Device: "/dev/sda"}
+
+	if err := WriteSystemConfigToVar(t.Context(), varMount, cfg, false, reporter.NoopReporter{}); err != nil {
+		t.Fatalf("WriteSystemConfigToVar: %v", err)
+	}
+
+	stateDir := filepath.Join(varMount, "lib", "nbc", "state")
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "config.json" {
+			t.Errorf("unexpected leftover file in state dir: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
Fixes #93.

## Problem
The shared A/B system config `/var/lib/nbc/state/config.json` was written with `os.WriteFile`, which **truncates the destination before writing**. A crash or power loss mid-write — which happens right after an update, exactly when this is written — corrupts the config for **both** A/B root slots. Worse, `ReadSystemConfig` only fell back to the legacy `/etc/nbc/config.json` when the primary was **absent**; a present-but-corrupt primary hard-failed `status`/`update`/`download` with a parse error and no recovery path.

## Fix
- **Atomic writes:** `WriteSystemConfig` and `WriteSystemConfigToVar` now write through `atomicWriteFile` (temp file → fsync → rename → dir fsync — the helper added in #87/#116), so a torn write leaves either the old or the new file intact, never a truncated one.
- **Corrupt-primary fallback:** extracted `loadSystemConfig`/`readAndParseConfig`; `ReadSystemConfig` falls back to the legacy config when the primary is missing **or** unparseable. The "not installed" message is preserved only when both are truly absent, and a corruption error is surfaced (never masked as not-found) when the primary is corrupt and there's no legacy copy.

## Tests
`pkg/config_fallback_test.go` covers the fallback matrix (valid primary preferred; corrupt→legacy; missing→legacy; both-missing→not-found error; corrupt+no-legacy→surfaced error) and that the var write leaves no temp litter.

Verified: `make fmt-check`, `build`, `test-unit`, `lint` (0 issues), `go vet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)