### PR TITLE
fix(dracut): declare crypt dependency in 95etc-overlay module (#98)

### DIFF
--- a/pkg/dracut/95etc-overlay/module-setup.sh
+++ b/pkg/dracut/95etc-overlay/module-setup.sh
@@ -15,9 +15,12 @@ check() {
 }
 
 depends() {
-    # We need the crypt module to be loaded first if LUKS is in use,
-    # so that /var can be unlocked before we try to mount the overlay
-    echo "rootfs-block"
+    # Declare the crypt module as a dependency so it is force-included in the
+    # initramfs even for generic (non-hostonly) image builds where the build
+    # host has no LUKS devices for crypt's own check() to auto-detect. Without
+    # this, an encrypted /var could not be unlocked before we mount the overlay.
+    # rootfs-block is kept for block-device setup ordering.
+    echo "crypt rootfs-block"
     return 0
 }
 

--- a/pkg/dracut_depends_test.go
+++ b/pkg/dracut_depends_test.go
@@ -1,0 +1,25 @@
+package pkg
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestDracutModuleDeclaresCryptDependency is the regression test for #98. The
+// 95etc-overlay module must declare the crypt dracut module in depends() so it
+// is force-included in the initramfs even for generic (non-hostonly) image
+// builds; otherwise an encrypted /var cannot be unlocked before the overlay is
+// mounted. We assert the *shipped* (embedded) module, since that is what nbc
+// installs. The check targets the echoed dependency line, not the explanatory
+// comment (which also mentions crypt).
+func TestDracutModuleDeclaresCryptDependency(t *testing.T) {
+	content, err := dracutModuleFS.ReadFile("dracut/95etc-overlay/module-setup.sh")
+	if err != nil {
+		t.Fatalf("read embedded module-setup.sh: %v", err)
+	}
+
+	echoCrypt := regexp.MustCompile(`(?m)^\s*echo\s+"[^"]*\bcrypt\b[^"]*"`)
+	if !echoCrypt.Match(content) {
+		t.Errorf("module-setup.sh depends() must echo the 'crypt' dependency (#98)")
+	}
+}


### PR DESCRIPTION
Fixes #98.

## Problem
The `95etc-overlay` dracut module's `depends()` comment says it needs the `crypt` module (so an encrypted `/var` can be unlocked before the overlay is mounted), but it only echoed `"rootfs-block"` — a lower-level module that `crypt` itself depends on, not the reverse. Declaring `rootfs-block` does not force `crypt` to be included.

In a generic (non-hostonly) image build — where the build host has no LUKS device for `crypt`'s own `check()` to auto-detect — `crypt` could be omitted from the initramfs entirely, leaving an encrypted `/var` unlockable at boot and the overlay unable to mount. `luks.go`'s `ValidateInitramfsSupport` only checks for the `90crypt` module *directory* in the source tree, so it wouldn't catch this either.

## Fix
`echo "crypt rootfs-block"` so dracut force-includes the crypt module.

## Test
`TestDracutModuleDeclaresCryptDependency` asserts the **shipped** (embedded) `module-setup.sh` echoes a `crypt` dependency (targeting the echoed line, not the explanatory comment). Verified it fails with the old `echo "rootfs-block"`.

Verified: `make fmt-check`, `test-unit`, `lint` (0 issues); `bash -n` on the script; no new shellcheck warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)