### PR TITLE
fix(luks): keep TPM2 enroll passphrase off disk (tmpfs + shred) (#97)

### DIFF
--- a/pkg/ephemeral_key.go
+++ b/pkg/ephemeral_key.go
@@ -54,10 +54,21 @@ func writeEphemeralKeyFile(secret string) (string, func(), error) {
 // this zeroes the backing RAM pages before they are freed; on other filesystems
 // it is best-effort (copy-on-write / wear-leveling may relocate blocks).
 func shredFile(path string) {
-	if info, err := os.Stat(path); err == nil && info.Size() > 0 {
-		if f, err := os.OpenFile(path, os.O_WRONLY, 0o600); err == nil {
-			zeros := make([]byte, info.Size())
-			_, _ = f.Write(zeros)
+	info, err := os.Stat(path)
+	if err == nil && info.Size() > 0 {
+		if f, err := os.OpenFile(path, os.O_WRONLY, 0); err == nil {
+			buf := make([]byte, 32*1024)
+			remaining := info.Size()
+			for remaining > 0 {
+				n := len(buf)
+				if remaining < int64(n) {
+					n = int(remaining)
+				}
+				if _, err := f.Write(buf[:n]); err != nil {
+					break
+				}
+				remaining -= int64(n)
+			}
 			_ = f.Sync()
 			_ = f.Close()
 		}

--- a/pkg/ephemeral_key.go
+++ b/pkg/ephemeral_key.go
@@ -1,0 +1,66 @@
+package pkg
+
+import (
+	"fmt"
+	"os"
+)
+
+// ephemeralKeyDirs lists preferred directories for transient secret files, in
+// priority order. These are tmpfs (memory-backed) on Linux, so a secret written
+// there never touches persistent storage. It is a variable so tests can
+// override it.
+var ephemeralKeyDirs = []string{"/dev/shm", "/run"}
+
+// createEphemeralKeyFile creates a 0600 temp file for a transient secret in the
+// first available preferred (tmpfs) directory, falling back to the default temp
+// dir if none is usable. os.CreateTemp already creates the file with 0600.
+func createEphemeralKeyFile(pattern string) (*os.File, error) {
+	for _, dir := range ephemeralKeyDirs {
+		if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+			continue
+		}
+		if f, err := os.CreateTemp(dir, pattern); err == nil {
+			return f, nil
+		}
+	}
+	return os.CreateTemp("", pattern)
+}
+
+// writeEphemeralKeyFile writes secret to a 0600 temp file in a tmpfs-backed
+// directory when available, and returns the path plus a cleanup func that
+// overwrites (best-effort shred) and removes the file. Keeping the secret off
+// disk is the primary protection; the overwrite is defense-in-depth.
+func writeEphemeralKeyFile(secret string) (string, func(), error) {
+	f, err := createEphemeralKeyFile("luks-key-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temporary key file: %w", err)
+	}
+	path := f.Name()
+	cleanup := func() { shredFile(path) }
+
+	if _, err := f.WriteString(secret); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("failed to write to temporary key file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("failed to close temporary key file: %w", err)
+	}
+	return path, cleanup, nil
+}
+
+// shredFile overwrites a file's contents with zeros before removing it. On tmpfs
+// this zeroes the backing RAM pages before they are freed; on other filesystems
+// it is best-effort (copy-on-write / wear-leveling may relocate blocks).
+func shredFile(path string) {
+	if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+		if f, err := os.OpenFile(path, os.O_WRONLY, 0o600); err == nil {
+			zeros := make([]byte, info.Size())
+			_, _ = f.Write(zeros)
+			_ = f.Sync()
+			_ = f.Close()
+		}
+	}
+	_ = os.Remove(path)
+}

--- a/pkg/ephemeral_key_test.go
+++ b/pkg/ephemeral_key_test.go
@@ -1,0 +1,79 @@
+package pkg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCreateEphemeralKeyFile_UsesPreferredDir verifies the transient key file is
+// created in a preferred (tmpfs) directory when one is available, so a LUKS
+// passphrase is not written to a possibly disk-backed /tmp (#97).
+func TestCreateEphemeralKeyFile_UsesPreferredDir(t *testing.T) {
+	preferred := t.TempDir()
+	orig := ephemeralKeyDirs
+	t.Cleanup(func() { ephemeralKeyDirs = orig })
+	ephemeralKeyDirs = []string{preferred}
+
+	f, err := createEphemeralKeyFile("luks-key-*")
+	if err != nil {
+		t.Fatalf("createEphemeralKeyFile: %v", err)
+	}
+	path := f.Name()
+	_ = f.Close()
+	defer func() { _ = os.Remove(path) }()
+
+	if got := filepath.Dir(path); got != preferred {
+		t.Errorf("key file created in %q, want preferred dir %q", got, preferred)
+	}
+}
+
+// TestCreateEphemeralKeyFile_FallsBackWhenNoneAvailable verifies we still create
+// a key file (in the default temp dir) if no preferred dir exists.
+func TestCreateEphemeralKeyFile_FallsBackWhenNoneAvailable(t *testing.T) {
+	orig := ephemeralKeyDirs
+	t.Cleanup(func() { ephemeralKeyDirs = orig })
+	ephemeralKeyDirs = []string{filepath.Join(t.TempDir(), "does-not-exist")}
+
+	f, err := createEphemeralKeyFile("luks-key-*")
+	if err != nil {
+		t.Fatalf("createEphemeralKeyFile fallback: %v", err)
+	}
+	path := f.Name()
+	_ = f.Close()
+	defer func() { _ = os.Remove(path) }()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("fallback key file should exist: %v", err)
+	}
+}
+
+// TestWriteEphemeralKeyFile_TightPermsAndCleanup verifies the secret is written
+// with 0600 permissions and the cleanup removes the file.
+func TestWriteEphemeralKeyFile_TightPermsAndCleanup(t *testing.T) {
+	preferred := t.TempDir()
+	orig := ephemeralKeyDirs
+	t.Cleanup(func() { ephemeralKeyDirs = orig })
+	ephemeralKeyDirs = []string{preferred}
+
+	path, cleanup, err := writeEphemeralKeyFile("s3cr et with spaces")
+	if err != nil {
+		t.Fatalf("writeEphemeralKeyFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("key file perms = %o, want 0600", perm)
+	}
+	if data, _ := os.ReadFile(path); string(data) != "s3cr et with spaces" {
+		t.Errorf("key file content = %q", data)
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("cleanup should remove the key file, stat err = %v", err)
+	}
+}

--- a/pkg/luks.go
+++ b/pkg/luks.go
@@ -188,22 +188,14 @@ func EnrollTPM2(ctx context.Context, partition string, config *LUKSConfig, progr
 		keyFilePath = config.Keyfile
 		cleanup = func() {} // No cleanup needed
 	} else {
-		// Write passphrase to a temporary file (systemd-cryptenroll doesn't reliably read from stdin)
-		keyFile, err := os.CreateTemp("", "luks-key-*")
+		// systemd-cryptenroll doesn't reliably read the unlock key from stdin,
+		// so write the passphrase to a transient key file. Use a tmpfs-backed
+		// directory so the secret never touches persistent storage, and shred it
+		// on cleanup.
+		var err error
+		keyFilePath, cleanup, err = writeEphemeralKeyFile(config.Passphrase)
 		if err != nil {
-			return fmt.Errorf("failed to create temporary key file: %w", err)
-		}
-		keyFilePath = keyFile.Name()
-		cleanup = func() { _ = os.Remove(keyFilePath) }
-
-		if _, err := keyFile.WriteString(config.Passphrase); err != nil {
-			_ = keyFile.Close()
-			cleanup()
-			return fmt.Errorf("failed to write to temporary key file: %w", err)
-		}
-		if err := keyFile.Close(); err != nil {
-			cleanup()
-			return fmt.Errorf("failed to close temporary key file: %w", err)
+			return err
 		}
 	}
 	defer cleanup()


### PR DESCRIPTION
Fixes #97.

## Problem
`EnrollTPM2` wrote the LUKS passphrase to `os.CreateTemp("")` — which resolves to `os.TempDir()` (typically `/tmp`), not guaranteed to be tmpfs (e.g. a live/rescue installer with `/tmp` on disk) — and only `os.Remove`d it, with no overwrite. The plaintext disk-encryption passphrase was recoverable from persistent storage. This is inconsistent with the rest of `luks.go`, which passes secrets via stdin (`--key-file -`).

`systemd-cryptenroll` doesn't reliably read the unlock key from stdin, so a key *file* is genuinely needed here — the fix is to make that file ephemeral and off-disk.

## Fix
Add `writeEphemeralKeyFile`, which:
- creates the transient key file in a **tmpfs-backed** directory (`/dev/shm`, then `/run`, falling back to the default temp dir) so the secret never touches persistent storage,
- keeps `0600` perms,
- **shreds** (zero-overwrites) and removes it on cleanup.

Keeping it off disk is the primary protection; the overwrite is defense-in-depth (best-effort on COW/wear-leveled filesystems, but on tmpfs it zeroes the RAM pages before they're freed). `EnrollTPM2` now uses it.

## Tests
`pkg/ephemeral_key_test.go` covers preferred-dir selection, fallback when no preferred dir exists, `0600` perms, content (including spaces), and cleanup removal. The preferred-dir list is injected in tests so they're deterministic across environments.

Verified: `make fmt-check`, `build`, `test-unit`, `lint` (0 issues), `go vet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)