### PR TITLE
Handle ReadDir errors in etc overlay pollution diagnostics

### DIFF
--- a/pkg/etc_overlay_hook_test.go
+++ b/pkg/etc_overlay_hook_test.go
@@ -55,11 +55,20 @@ prepare_etc_lower
 
 func countEntries(t *testing.T, dir string) int {
 	t.Helper()
+	return len(entryNames(t, dir))
+}
+
+func entryNames(t *testing.T, dir string) []string {
+	t.Helper()
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("failed to read %s: %v", dir, err)
 	}
-	return len(entries)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
 }
 
 // newOverlaySandbox creates a fake sysroot with a populated /etc and the
@@ -118,15 +127,8 @@ func TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper(t *testing.T) {
 
 	// The core assertion: upper must remain empty. On the buggy hook it gets the
 	// entire /etc copied into it.
-	if got := countEntries(t, upper); got != 0 {
-		names, err := os.ReadDir(upper)
-		if err != nil {
-			t.Fatalf("failed to read upper dir: %v", err)
-		}
-		var polluted []string
-		for _, n := range names {
-			polluted = append(polluted, n.Name())
-		}
+	polluted := entryNames(t, upper)
+	if got := len(polluted); got != 0 {
 		t.Errorf("upper layer was polluted with %d entries from /etc: %v", got, polluted)
 	}
 


### PR DESCRIPTION
Summary: Fixes #115 by reading the upper directory exactly once in `TestEtcOverlayHook_PopulatedLowerDoesNotPolluteUpper`, handling the `os.ReadDir` error explicitly with `t.Fatalf`, and deriving both the entry count and polluted-name list from that single result. This eliminates the redundant double-read (previously `countEntries` + a second `os.ReadDir`) and ensures filesystem errors on the diagnostic path are never silently ignored. Task: #8