### PR TITLE
Fix exclusive cache lock held during entire network pull

### DIFF
--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -26,6 +26,8 @@ const (
 	StagedUpdateDir = "/var/cache/nbc/staged-update"
 	// MetadataFileName is the name of the metadata file in each cached image directory
 	MetadataFileName = "metadata.json"
+
+	downloadStagingPrefix = ".download-"
 )
 
 // Type alias for backward compatibility
@@ -77,15 +79,13 @@ func (c *ImageCache) GetLayoutPath(digest string) string {
 	return filepath.Join(c.CacheDir, digestToDir(digest))
 }
 
+func isCacheEntry(entry os.DirEntry) bool {
+	return entry.IsDir() && !strings.HasPrefix(entry.Name(), ".")
+}
+
+
 // Download pulls a container image and saves it to the cache in OCI layout format.
 func (c *ImageCache) Download(ctx context.Context, imageRef string, progress reporter.Reporter) (*CachedImageMetadata, error) {
-	// Acquire exclusive lock for cache write operation
-	lock, err := AcquireCacheLock()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = lock.Release() }()
-
 	// Parse image reference
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
@@ -111,55 +111,83 @@ func (c *ImageCache) Download(ctx context.Context, imageRef string, progress rep
 	}
 
 	digestStr := digest.String()
-	imageDir := filepath.Join(c.CacheDir, digestToDir(digestStr))
-
-	// Check if already cached (with valid metadata)
-	if _, err := os.Stat(imageDir); err == nil {
-		metadata, err := c.readMetadata(imageDir)
-		if err == nil {
-			progress.Message("Image already cached: %s", digestStr)
-			return metadata, nil
-		}
-		// Directory exists but metadata is missing/invalid - cleanup and re-download
-		progress.Message("Cleaning up incomplete cache entry: %s", digestStr)
-		_ = os.RemoveAll(imageDir)
-	}
 
 	progress.Message("Saving image to cache: %s", digestStr)
 
 	// Create cache directory
-	if err := os.MkdirAll(imageDir, 0755); err != nil {
+	if err := os.MkdirAll(c.CacheDir, 0755); err != nil {
 		return nil, fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	// Write OCI layout
-	layoutPath, err := layout.Write(imageDir, empty.Index)
+	stagingDir, err := os.MkdirTemp(c.CacheDir, downloadStagingPrefix+"*")
 	if err != nil {
-		_ = os.RemoveAll(imageDir)
+		return nil, fmt.Errorf("failed to create staging directory: %w", err)
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
+
+	// Write OCI layout
+	layoutPath, err := layout.Write(stagingDir, empty.Index)
+	if err != nil {
 		return nil, fmt.Errorf("failed to create OCI layout: %w", err)
 	}
 
 	// Append image to layout
 	if err := layoutPath.AppendImage(img); err != nil {
-		_ = os.RemoveAll(imageDir)
 		return nil, fmt.Errorf("failed to write image to layout: %w", err)
 	}
 
 	// Extract metadata from image
 	metadata, err := c.extractMetadata(img, imageRef, digestStr)
 	if err != nil {
-		_ = os.RemoveAll(imageDir)
 		return nil, fmt.Errorf("failed to extract metadata: %w", err)
 	}
 
 	// Write metadata file
-	if err := c.writeMetadata(imageDir, metadata); err != nil {
-		_ = os.RemoveAll(imageDir)
+	if err := c.writeMetadata(stagingDir, metadata); err != nil {
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	progress.Message("Image cached successfully: %s", digestStr)
+	metadata, committed, err = c.commitDownload(stagingDir, digestStr, metadata, progress)
+	if err != nil {
+		return nil, err
+	}
 	return metadata, nil
+}
+
+// commitDownload atomically publishes a staged OCI layout directory into the cache.
+func (c *ImageCache) commitDownload(stagingDir, digestStr string, metadata *CachedImageMetadata, progress reporter.Reporter) (*CachedImageMetadata, bool, error) {
+	lock, err := AcquireCacheLock()
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = lock.Release() }()
+
+	imageDir := c.GetLayoutPath(digestStr)
+
+	// Another process may have committed this digest while the image was being staged.
+	if _, err := os.Stat(imageDir); err == nil {
+		existing, readErr := c.readMetadata(imageDir)
+		if readErr == nil {
+			progress.Message("Image already cached: %s", digestStr)
+			return existing, false, nil
+		}
+
+		progress.Message("Cleaning up incomplete cache entry: %s", digestStr)
+		_ = os.RemoveAll(imageDir)
+	}
+
+	if err := os.Rename(stagingDir, imageDir); err != nil {
+		return nil, false, fmt.Errorf("failed to commit image to cache: %w", err)
+	}
+
+	progress.Message("Image cached successfully: %s", digestStr)
+	return metadata, true, nil
 }
 
 // extractMetadata extracts metadata from a container image
@@ -250,7 +278,7 @@ func (c *ImageCache) GetImage(digestOrRef string) (v1.Image, *CachedImageMetadat
 
 	var matches []string
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isCacheEntry(entry) {
 			continue
 		}
 		// Check if this entry matches the digest prefix
@@ -330,7 +358,7 @@ func (c *ImageCache) listUnlocked() ([]CachedImageMetadata, error) {
 	}
 
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		if !isCacheEntry(entry) {
 			continue
 		}
 

--- a/pkg/cache.go
+++ b/pkg/cache.go
@@ -83,7 +83,6 @@ func isCacheEntry(entry os.DirEntry) bool {
 	return entry.IsDir() && !strings.HasPrefix(entry.Name(), ".")
 }
 
-
 // Download pulls a container image and saves it to the cache in OCI layout format.
 func (c *ImageCache) Download(ctx context.Context, imageRef string, progress reporter.Reporter) (*CachedImageMetadata, error) {
 	// Parse image reference

--- a/pkg/cache_test.go
+++ b/pkg/cache_test.go
@@ -3,10 +3,68 @@ package pkg
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/frostyard/std/reporter"
 )
+
+func testCachedImageMetadata(imageRef, digest string) *CachedImageMetadata {
+	return &CachedImageMetadata{
+		ImageRef:            imageRef,
+		ImageDigest:         digest,
+		DownloadDate:        "2024-01-01T00:00:00Z",
+		Architecture:        "amd64",
+		Labels:              map[string]string{"version": "1.0"},
+		OSReleasePrettyName: "Test OS",
+		OSReleaseVersionID:  "1.0",
+		OSReleaseID:         "testos",
+		SizeBytes:           1024 * 1024,
+	}
+}
+
+func makeStagingDir(t *testing.T, cache *ImageCache, metadata *CachedImageMetadata) string {
+	t.Helper()
+
+	stagingDir, err := os.MkdirTemp(cache.CacheDir, ".download-*")
+	if err != nil {
+		t.Fatalf("failed to create staging dir: %v", err)
+	}
+
+	if err := cache.writeMetadata(stagingDir, metadata); err != nil {
+		t.Fatalf("failed to write staging metadata: %v", err)
+	}
+
+	return stagingDir
+}
+
+func assertMetadataEqual(t *testing.T, got, want *CachedImageMetadata) {
+	t.Helper()
+
+	if got.ImageRef != want.ImageRef {
+		t.Errorf("ImageRef = %q, want %q", got.ImageRef, want.ImageRef)
+	}
+	if got.ImageDigest != want.ImageDigest {
+		t.Errorf("ImageDigest = %q, want %q", got.ImageDigest, want.ImageDigest)
+	}
+	if got.Architecture != want.Architecture {
+		t.Errorf("Architecture = %q, want %q", got.Architecture, want.Architecture)
+	}
+	if got.SizeBytes != want.SizeBytes {
+		t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, want.SizeBytes)
+	}
+}
+
+func skipIfNoCacheLockPermission(t *testing.T) {
+	t.Helper()
+
+	if err := ensureLockDir(); err != nil {
+		if os.IsPermission(err) || strings.Contains(err.Error(), "permission denied") {
+			t.Skip("Skipping test: no permission to create /var/run/nbc")
+		}
+		t.Fatalf("ensureLockDir failed: %v", err)
+	}
+}
 
 func TestNewImageCache(t *testing.T) {
 	cache := NewImageCache("/test/path")
@@ -88,6 +146,163 @@ func TestImageCache_List_NonExistentDirectory(t *testing.T) {
 	}
 	if len(images) != 0 {
 		t.Errorf("List() returned %d images, want 0", len(images))
+	}
+}
+
+func TestCacheCommitDownload_AtomicMove(t *testing.T) {
+	skipIfNoCacheLockPermission(t)
+
+	tmpDir := t.TempDir()
+	cache := NewImageCache(tmpDir)
+	metadata := testCachedImageMetadata("quay.io/test/image:v1", "sha256:abc123")
+	stagingDir := makeStagingDir(t, cache, metadata)
+
+	sharedLock, err := AcquireCacheLockShared()
+	if err != nil {
+		t.Fatalf("AcquireCacheLockShared() during staging failed: %v", err)
+	}
+	if err := sharedLock.Release(); err != nil {
+		t.Fatalf("failed to release shared cache lock: %v", err)
+	}
+
+	got, committed, err := cache.commitDownload(stagingDir, metadata.ImageDigest, metadata, reporter.NoopReporter{})
+	if err != nil {
+		t.Fatalf("commitDownload() error = %v", err)
+	}
+	if !committed {
+		t.Fatal("commitDownload() committed = false, want true")
+	}
+	assertMetadataEqual(t, got, metadata)
+
+	finalDir := filepath.Join(tmpDir, "sha256-abc123")
+	if _, err := os.Stat(finalDir); err != nil {
+		t.Fatalf("final image dir does not exist: %v", err)
+	}
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Fatalf("staging dir should have been renamed away, stat err = %v", err)
+	}
+}
+
+func TestCacheCommitDownload_DedupWhenAlreadyCached(t *testing.T) {
+	skipIfNoCacheLockPermission(t)
+
+	tmpDir := t.TempDir()
+	cache := NewImageCache(tmpDir)
+	existing := testCachedImageMetadata("quay.io/test/existing:v1", "sha256:abc123")
+	staged := testCachedImageMetadata("quay.io/test/staged:v1", "sha256:abc123")
+
+	finalDir := filepath.Join(tmpDir, "sha256-abc123")
+	if err := os.MkdirAll(finalDir, 0755); err != nil {
+		t.Fatalf("failed to create final dir: %v", err)
+	}
+	if err := cache.writeMetadata(finalDir, existing); err != nil {
+		t.Fatalf("failed to write existing metadata: %v", err)
+	}
+	stagingDir := makeStagingDir(t, cache, staged)
+
+	got, committed, err := cache.commitDownload(stagingDir, staged.ImageDigest, staged, reporter.NoopReporter{})
+	if err != nil {
+		t.Fatalf("commitDownload() error = %v", err)
+	}
+	if committed {
+		t.Fatal("commitDownload() committed = true, want false")
+	}
+	assertMetadataEqual(t, got, existing)
+	if _, err := os.Stat(stagingDir); err != nil {
+		t.Fatalf("staging dir should be left for caller cleanup: %v", err)
+	}
+}
+
+func TestCacheCommitDownload_ReplacesIncompleteEntry(t *testing.T) {
+	skipIfNoCacheLockPermission(t)
+
+	tmpDir := t.TempDir()
+	cache := NewImageCache(tmpDir)
+	metadata := testCachedImageMetadata("quay.io/test/image:v1", "sha256:abc123")
+
+	finalDir := filepath.Join(tmpDir, "sha256-abc123")
+	if err := os.MkdirAll(finalDir, 0755); err != nil {
+		t.Fatalf("failed to create incomplete final dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(finalDir, "partial"), []byte("incomplete"), 0644); err != nil {
+		t.Fatalf("failed to write incomplete marker: %v", err)
+	}
+	stagingDir := makeStagingDir(t, cache, metadata)
+
+	got, committed, err := cache.commitDownload(stagingDir, metadata.ImageDigest, metadata, reporter.NoopReporter{})
+	if err != nil {
+		t.Fatalf("commitDownload() error = %v", err)
+	}
+	if !committed {
+		t.Fatal("commitDownload() committed = false, want true")
+	}
+	assertMetadataEqual(t, got, metadata)
+
+	if _, err := os.Stat(filepath.Join(finalDir, "partial")); !os.IsNotExist(err) {
+		t.Fatalf("incomplete entry should have been replaced, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(finalDir, MetadataFileName)); err != nil {
+		t.Fatalf("replacement metadata missing: %v", err)
+	}
+}
+
+func TestCacheListUnlocked_SkipsStagingDirs(t *testing.T) {
+	skipIfNoCacheLockPermission(t)
+
+	tmpDir := t.TempDir()
+	cache := NewImageCache(tmpDir)
+
+	valid := testCachedImageMetadata("quay.io/test/image:v1", "sha256:abc123")
+	validDir := filepath.Join(tmpDir, "sha256-abc123")
+	if err := os.MkdirAll(validDir, 0755); err != nil {
+		t.Fatalf("failed to create valid image dir: %v", err)
+	}
+	if err := cache.writeMetadata(validDir, valid); err != nil {
+		t.Fatalf("failed to write valid metadata: %v", err)
+	}
+
+	stagingDir := filepath.Join(tmpDir, ".download-abc123")
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		t.Fatalf("failed to create staging dir: %v", err)
+	}
+	if err := cache.writeMetadata(stagingDir, testCachedImageMetadata("quay.io/test/staged:v1", "sha256:def456")); err != nil {
+		t.Fatalf("failed to write staging metadata: %v", err)
+	}
+
+	images, err := cache.List()
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("List() returned %d images, want 1", len(images))
+	}
+	if images[0].ImageDigest != valid.ImageDigest {
+		t.Errorf("List()[0].ImageDigest = %q, want %q", images[0].ImageDigest, valid.ImageDigest)
+	}
+}
+
+func TestCacheGetImage_IgnoresStagingDirs(t *testing.T) {
+	skipIfNoCacheLockPermission(t)
+
+	tmpDir := t.TempDir()
+	cache := NewImageCache(tmpDir)
+
+	stagingDir := filepath.Join(tmpDir, ".download-sha256-abc123")
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		t.Fatalf("failed to create staging dir: %v", err)
+	}
+	staged := testCachedImageMetadata("quay.io/test/staged:v1", "sha256:abc123")
+	if err := cache.writeMetadata(stagingDir, staged); err != nil {
+		t.Fatalf("failed to write staging metadata: %v", err)
+	}
+
+	_, _, err := cache.GetImage(staged.ImageRef)
+	if err == nil {
+		t.Fatal("GetImage() should ignore staging dir and report not found")
+	}
+	expected := "image not found in cache: " + staged.ImageRef
+	if err.Error() != expected {
+		t.Fatalf("GetImage() error = %q, want %q", err.Error(), expected)
 	}
 }
 


### PR DESCRIPTION
Summary: Rewrites `Download()` in `pkg/cache.go` to stage the OCI layout into a temporary directory inside `CacheDir` with no lock held, then acquires the exclusive cache lock only for the short atomic `os.Rename` commit. This fixes issue #101 where concurrent read-only operations (list, status, get) would fail immediately with a lock error for the entire duration of a potentially multi-minute download. Adds a `commitDownload()` helper, dot-prefix skip guards in directory scanners, and five unit tests covering the fix. Task: #7