### PR TITLE
refactor(cmdline): unify install/update kernel cmdline construction (#95)

### DIFF
--- a/pkg/bootloader.go
+++ b/pkg/bootloader.go
@@ -71,101 +71,56 @@ func (b *BootloaderInstaller) SetEncryption(config *LUKSConfig) {
 	b.Encryption = config
 }
 
-// buildKernelCmdline builds the kernel command line with LUKS support if encrypted
+// buildKernelCmdline builds the kernel command line with LUKS support if
+// encrypted. It gathers the install-specific inputs and delegates the actual
+// assembly to assembleKernelCmdline, which the update flow also uses so the two
+// can never diverge.
 func (b *BootloaderInstaller) buildKernelCmdline(ctx context.Context) ([]string, error) {
-	fsType := b.Scheme.FilesystemType
-	if fsType == "" {
-		fsType = "ext4"
+	bootUUID, err := GetPartitionUUID(ctx, b.Scheme.BootPartition)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get boot UUID: %w", err)
 	}
 
-	var kernelCmdline []string
-	var varSpec string // /var device specification for overlay
+	params := kernelCmdlineParams{
+		FilesystemType: b.Scheme.FilesystemType,
+		BootUUID:       bootUUID,
+		ExtraArgs:      b.KernelArgs,
+	}
 
 	if b.Scheme.Encrypted {
-		// LUKS encrypted root - use device mapper path
+		// A fresh install always sets up the primary slot as root1.
 		rootDev := b.Scheme.GetLUKSDevice("root1")
 		varDev := b.Scheme.GetLUKSDevice("var")
-
 		if rootDev == nil || varDev == nil {
 			return nil, fmt.Errorf("LUKS devices not found for encrypted scheme")
 		}
+		params.Encrypted = true
+		params.TPM2 = b.Encryption != nil && b.Encryption.TPM2
+		params.RootMapperName = "root1"
+		params.RootLUKSUUID = rootDev.LUKSUUID
+		params.VarLUKSUUID = varDev.LUKSUUID
 
-		// Root via device mapper
-		kernelCmdline = append(kernelCmdline, "root=/dev/mapper/root1")
-		kernelCmdline = append(kernelCmdline, "ro")
-
-		// LUKS UUIDs for initramfs to discover and unlock
-		kernelCmdline = append(kernelCmdline, "rd.luks.uuid="+rootDev.LUKSUUID)
-		kernelCmdline = append(kernelCmdline, "rd.luks.name="+rootDev.LUKSUUID+"=root1")
-
-		// Var partition via device mapper
-		kernelCmdline = append(kernelCmdline, "rd.luks.uuid="+varDev.LUKSUUID)
-		kernelCmdline = append(kernelCmdline, "rd.luks.name="+varDev.LUKSUUID+"=var")
-
-		// TPM2 auto-unlock if enabled
-		if b.Encryption != nil && b.Encryption.TPM2 {
-			if b.Verbose {
+		if b.Verbose {
+			if params.TPM2 {
 				b.Progress.Message("Adding TPM2 unlock options to kernel cmdline")
+			} else {
+				b.Progress.Message("TPM2 options not added: Encryption=%v, TPM2=%v", b.Encryption != nil, params.TPM2)
 			}
-			kernelCmdline = append(kernelCmdline, "rd.luks.options="+rootDev.LUKSUUID+"=tpm2-device=auto")
-			kernelCmdline = append(kernelCmdline, "rd.luks.options="+varDev.LUKSUUID+"=tpm2-device=auto")
-		} else if b.Verbose {
-			b.Progress.Message("TPM2 options not added: Encryption=%v, TPM2=%v", b.Encryption != nil, b.Encryption != nil && b.Encryption.TPM2)
 		}
-
-		// Mount boot partition via systemd.mount-extra (always FAT32, never encrypted)
-		bootUUID, err := GetPartitionUUID(ctx, b.Scheme.BootPartition)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get boot UUID: %w", err)
-		}
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+bootUUID+":/boot:vfat:defaults")
-
-		// Mount /var via systemd.mount-extra using mapper device
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=/dev/mapper/var:/var:"+fsType+":defaults")
-		varSpec = "/dev/mapper/var"
 	} else {
-		// Non-encrypted root - use UUID
 		rootUUID, err := GetPartitionUUID(ctx, b.Scheme.Root1Partition)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get root UUID: %w", err)
 		}
-
 		varUUID, err := GetPartitionUUID(ctx, b.Scheme.VarPartition)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get var UUID: %w", err)
 		}
-
-		// Get boot partition UUID (always FAT32, never encrypted)
-		bootUUID, err := GetPartitionUUID(ctx, b.Scheme.BootPartition)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get boot UUID: %w", err)
-		}
-
-		kernelCmdline = append(kernelCmdline, "root=UUID="+rootUUID)
-		kernelCmdline = append(kernelCmdline, "ro")
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+bootUUID+":/boot:vfat:defaults")
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+varUUID+":/var:"+fsType+":defaults")
-		varSpec = "UUID=" + varUUID
+		params.RootUUID = rootUUID
+		params.VarUUID = varUUID
 	}
 
-	// Enable /etc overlay persistence
-	// The dracut module 95etc-overlay will mount an overlayfs for /etc
-	// with the root filesystem as lowerdir and /var/lib/nbc/etc-overlay as upperdir
-	kernelCmdline = append(kernelCmdline, "rd.etc.overlay=1")
-	kernelCmdline = append(kernelCmdline, "rd.etc.overlay.var="+varSpec)
-
-	// HACK: Disable NVMe multipath to ensure stable device naming across reboots
-	// Modern kernels have CONFIG_NVME_MULTIPATH=y by default, causing nvme0/nvme1
-	// to swap between boots due to non-deterministic controller enumeration order.
-	// This is a workaround - ideally we should always use /dev/disk/by-id/* or UUIDs
-	// everywhere and not rely on /dev/nvmeXnY naming at all.
-	// TODO: Audit all code for hardcoded /dev/nvme* paths and migrate to stable identifiers
-	kernelCmdline = append(kernelCmdline, "nvme_core.multipath=N")
-
-	// Add user-specified kernel arguments
-	kernelCmdline = append(kernelCmdline, b.KernelArgs...)
-
-	return kernelCmdline, nil
+	return assembleKernelCmdline(params), nil
 }
 
 // ensureUppercaseEFIDirectory ensures the EFI directory structure uses proper uppercase naming

--- a/pkg/kernelcmdline.go
+++ b/pkg/kernelcmdline.go
@@ -23,6 +23,19 @@ type kernelCmdlineParams struct {
 	ExtraArgs []string // user-supplied kernel arguments, appended last
 }
 
+// updateRootSlot picks which root slot a cmdline is being built for during an
+// A/B update. The target (new) root is the currently-inactive slot; the
+// non-target case is the active/previous slot. root1Active reports whether root1
+// is the currently-active slot. It returns the mapper name ("root1"/"root2") and
+// whether the second slot was chosen.
+func updateRootSlot(isTarget, root1Active bool) (mapperName string, useRoot2 bool) {
+	useRoot2 = (isTarget && root1Active) || (!isTarget && !root1Active)
+	if useRoot2 {
+		return "root2", true
+	}
+	return "root1", false
+}
+
 // assembleKernelCmdline builds the ordered kernel command line from params. It is
 // pure (no I/O) so both flows share one authoritative definition of the cmdline
 // format.

--- a/pkg/kernelcmdline.go
+++ b/pkg/kernelcmdline.go
@@ -1,0 +1,81 @@
+package pkg
+
+// kernelCmdlineParams holds everything needed to build the kernel command line.
+// Both the install and update flows populate this and call assembleKernelCmdline,
+// so the two produce identical output and can never drift (see the "Install and
+// Update Parity" note in CLAUDE.md).
+type kernelCmdlineParams struct {
+	Encrypted      bool
+	TPM2           bool
+	FilesystemType string // "ext4"/"btrfs"; defaults to ext4 when empty
+
+	// Encrypted systems (device-mapper root + var):
+	RootMapperName string // "root1" or "root2"
+	RootLUKSUUID   string
+	VarLUKSUUID    string
+
+	// Non-encrypted systems (partition UUIDs):
+	RootUUID string
+	VarUUID  string
+
+	// Always required:
+	BootUUID  string
+	ExtraArgs []string // user-supplied kernel arguments, appended last
+}
+
+// assembleKernelCmdline builds the ordered kernel command line from params. It is
+// pure (no I/O) so both flows share one authoritative definition of the cmdline
+// format.
+func assembleKernelCmdline(p kernelCmdlineParams) []string {
+	fsType := p.FilesystemType
+	if fsType == "" {
+		fsType = "ext4"
+	}
+
+	var cmdline []string
+	if p.Encrypted {
+		// Root via device mapper.
+		cmdline = append(cmdline, "root=/dev/mapper/"+p.RootMapperName, "ro")
+
+		// LUKS UUIDs for the initramfs to discover and unlock.
+		cmdline = append(cmdline,
+			"rd.luks.uuid="+p.RootLUKSUUID,
+			"rd.luks.name="+p.RootLUKSUUID+"="+p.RootMapperName,
+			"rd.luks.uuid="+p.VarLUKSUUID,
+			"rd.luks.name="+p.VarLUKSUUID+"=var",
+		)
+
+		// TPM2 auto-unlock (no PCR binding) when enabled.
+		if p.TPM2 {
+			cmdline = append(cmdline,
+				"rd.luks.options="+p.RootLUKSUUID+"=tpm2-device=auto",
+				"rd.luks.options="+p.VarLUKSUUID+"=tpm2-device=auto",
+			)
+		}
+
+		// Boot (FAT32, never encrypted) and var (mapper device) mounts.
+		cmdline = append(cmdline,
+			"systemd.mount-extra=UUID="+p.BootUUID+":/boot:vfat:defaults",
+			"systemd.mount-extra=/dev/mapper/var:/var:"+fsType+":defaults",
+			"rd.etc.overlay=1",
+			"rd.etc.overlay.var=/dev/mapper/var",
+		)
+	} else {
+		cmdline = append(cmdline,
+			"root=UUID="+p.RootUUID, "ro",
+			"systemd.mount-extra=UUID="+p.BootUUID+":/boot:vfat:defaults",
+			"systemd.mount-extra=UUID="+p.VarUUID+":/var:"+fsType+":defaults",
+			"rd.etc.overlay=1",
+			"rd.etc.overlay.var=UUID="+p.VarUUID,
+		)
+	}
+
+	// HACK: Disable NVMe multipath so nvme0/nvme1 device naming stays stable
+	// across reboots (CONFIG_NVME_MULTIPATH=y otherwise enumerates them
+	// non-deterministically).
+	cmdline = append(cmdline, "nvme_core.multipath=N")
+
+	// User-supplied arguments last.
+	cmdline = append(cmdline, p.ExtraArgs...)
+	return cmdline
+}

--- a/pkg/kernelcmdline_test.go
+++ b/pkg/kernelcmdline_test.go
@@ -80,23 +80,55 @@ func TestAssembleKernelCmdline_DefaultsFilesystemToExt4(t *testing.T) {
 	}
 }
 
-// TestAssembleKernelCmdline_InstallUpdateParity documents the whole point of the
-// refactor: install and update build the cmdline through the same function, so
-// equivalent inputs yield byte-identical output. Here the install case (root1,
-// hardcoded) and the update case targeting root1 produce the same result.
-func TestAssembleKernelCmdline_InstallUpdateParity(t *testing.T) {
-	base := kernelCmdlineParams{
-		Encrypted:      true,
-		TPM2:           true,
-		FilesystemType: "btrfs",
-		RootMapperName: "root1",
-		RootLUKSUUID:   "RL",
-		VarLUKSUUID:    "VL",
-		BootUUID:       "BOOT",
-		ExtraArgs:      []string{"quiet", "splash"},
+func TestUpdateRootSlot(t *testing.T) {
+	tests := []struct {
+		isTarget, root1Active bool
+		wantMapper            string
+		wantUseRoot2          bool
+	}{
+		// target = inactive slot
+		{isTarget: true, root1Active: true, wantMapper: "root2", wantUseRoot2: true},
+		{isTarget: true, root1Active: false, wantMapper: "root1", wantUseRoot2: false},
+		// non-target = active slot
+		{isTarget: false, root1Active: true, wantMapper: "root1", wantUseRoot2: false},
+		{isTarget: false, root1Active: false, wantMapper: "root2", wantUseRoot2: true},
 	}
-	installCmdline := assembleKernelCmdline(base)
-	updateCmdline := assembleKernelCmdline(base)
+	for _, tt := range tests {
+		gotMapper, gotUseRoot2 := updateRootSlot(tt.isTarget, tt.root1Active)
+		if gotMapper != tt.wantMapper || gotUseRoot2 != tt.wantUseRoot2 {
+			t.Errorf("updateRootSlot(isTarget=%v, root1Active=%v) = (%q, %v), want (%q, %v)",
+				tt.isTarget, tt.root1Active, gotMapper, gotUseRoot2, tt.wantMapper, tt.wantUseRoot2)
+		}
+	}
+}
+
+// TestAssembleKernelCmdline_InstallUpdateParity documents the whole point of the
+// refactor: install (which hardcodes root1) and an update that targets root1
+// must produce byte-identical cmdlines. The update side derives its root slot
+// via updateRootSlot rather than hardcoding it, so this exercises that logic
+// landing on root1 and matching the install output.
+func TestAssembleKernelCmdline_InstallUpdateParity(t *testing.T) {
+	const rootLUKS, varLUKS, boot = "R1LUKS", "VLUKS", "BOOT"
+	extra := []string{"quiet", "splash"}
+
+	// Install always targets root1.
+	installCmdline := assembleKernelCmdline(kernelCmdlineParams{
+		Encrypted: true, TPM2: true, FilesystemType: "btrfs",
+		RootMapperName: "root1", RootLUKSUUID: rootLUKS, VarLUKSUUID: varLUKS,
+		BootUUID: boot, ExtraArgs: extra,
+	})
+
+	// Update targeting the new root while root2 is currently active -> root1.
+	mapper, useRoot2 := updateRootSlot(true /*isTarget*/, false /*root1Active*/)
+	if useRoot2 || mapper != "root1" {
+		t.Fatalf("precondition: expected update to target root1, got %q", mapper)
+	}
+	updateCmdline := assembleKernelCmdline(kernelCmdlineParams{
+		Encrypted: true, TPM2: true, FilesystemType: "btrfs",
+		RootMapperName: mapper, RootLUKSUUID: rootLUKS, VarLUKSUUID: varLUKS,
+		BootUUID: boot, ExtraArgs: extra,
+	})
+
 	if !reflect.DeepEqual(installCmdline, updateCmdline) {
 		t.Errorf("install and update cmdlines diverged:\ninstall %v\nupdate  %v", installCmdline, updateCmdline)
 	}

--- a/pkg/kernelcmdline_test.go
+++ b/pkg/kernelcmdline_test.go
@@ -1,0 +1,103 @@
+package pkg
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAssembleKernelCmdline_NonEncrypted(t *testing.T) {
+	got := assembleKernelCmdline(kernelCmdlineParams{
+		FilesystemType: "btrfs",
+		RootUUID:       "ROOT",
+		VarUUID:        "VAR",
+		BootUUID:       "BOOT",
+		ExtraArgs:      []string{"quiet", "splash"},
+	})
+	want := []string{
+		"root=UUID=ROOT", "ro",
+		"systemd.mount-extra=UUID=BOOT:/boot:vfat:defaults",
+		"systemd.mount-extra=UUID=VAR:/var:btrfs:defaults",
+		"rd.etc.overlay=1", "rd.etc.overlay.var=UUID=VAR",
+		"nvme_core.multipath=N",
+		"quiet", "splash",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got  %v\nwant %v", got, want)
+	}
+}
+
+func TestAssembleKernelCmdline_EncryptedWithTPM2(t *testing.T) {
+	got := assembleKernelCmdline(kernelCmdlineParams{
+		Encrypted:      true,
+		TPM2:           true,
+		FilesystemType: "ext4",
+		RootMapperName: "root2",
+		RootLUKSUUID:   "RL",
+		VarLUKSUUID:    "VL",
+		BootUUID:       "BOOT",
+		ExtraArgs:      []string{"quiet"},
+	})
+	want := []string{
+		"root=/dev/mapper/root2", "ro",
+		"rd.luks.uuid=RL", "rd.luks.name=RL=root2",
+		"rd.luks.uuid=VL", "rd.luks.name=VL=var",
+		"rd.luks.options=RL=tpm2-device=auto", "rd.luks.options=VL=tpm2-device=auto",
+		"systemd.mount-extra=UUID=BOOT:/boot:vfat:defaults",
+		"systemd.mount-extra=/dev/mapper/var:/var:ext4:defaults",
+		"rd.etc.overlay=1", "rd.etc.overlay.var=/dev/mapper/var",
+		"nvme_core.multipath=N",
+		"quiet",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got  %v\nwant %v", got, want)
+	}
+}
+
+func TestAssembleKernelCmdline_EncryptedNoTPM2OmitsOptions(t *testing.T) {
+	got := assembleKernelCmdline(kernelCmdlineParams{
+		Encrypted:      true,
+		FilesystemType: "ext4",
+		RootMapperName: "root1",
+		RootLUKSUUID:   "RL",
+		VarLUKSUUID:    "VL",
+		BootUUID:       "BOOT",
+	})
+	for _, a := range got {
+		if strings.Contains(a, "tpm2-device") {
+			t.Errorf("no TPM2 options expected without TPM2, got %v", got)
+		}
+	}
+}
+
+func TestAssembleKernelCmdline_DefaultsFilesystemToExt4(t *testing.T) {
+	got := assembleKernelCmdline(kernelCmdlineParams{
+		RootUUID: "ROOT", VarUUID: "VAR", BootUUID: "BOOT",
+	})
+	joined := strings.Join(got, " ")
+	if !strings.Contains(joined, ":/var:ext4:defaults") {
+		t.Errorf("expected ext4 default for var mount, got %v", got)
+	}
+}
+
+// TestAssembleKernelCmdline_InstallUpdateParity documents the whole point of the
+// refactor: install and update build the cmdline through the same function, so
+// equivalent inputs yield byte-identical output. Here the install case (root1,
+// hardcoded) and the update case targeting root1 produce the same result.
+func TestAssembleKernelCmdline_InstallUpdateParity(t *testing.T) {
+	base := kernelCmdlineParams{
+		Encrypted:      true,
+		TPM2:           true,
+		FilesystemType: "btrfs",
+		RootMapperName: "root1",
+		RootLUKSUUID:   "RL",
+		VarLUKSUUID:    "VL",
+		BootUUID:       "BOOT",
+		ExtraArgs:      []string{"quiet", "splash"},
+	}
+	installCmdline := assembleKernelCmdline(base)
+	updateCmdline := assembleKernelCmdline(base)
+	if !reflect.DeepEqual(installCmdline, updateCmdline) {
+		t.Errorf("install and update cmdlines diverged:\ninstall %v\nupdate  %v", installCmdline, updateCmdline)
+	}
+}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -282,101 +282,41 @@ func (u *SystemUpdater) SetLocalImage(layoutPath string, metadata *CachedImageMe
 
 // buildKernelCmdline builds the kernel command line with proper LUKS support if encrypted
 // isTarget indicates if this is for the target (new) root or the active (previous) root
+// buildKernelCmdline gathers the update-specific inputs (which root slot is the
+// target vs the active/previous one) and delegates assembly to
+// assembleKernelCmdline, shared with the install flow so the two never diverge.
 func (u *SystemUpdater) buildKernelCmdline(rootUUID, varUUID, fsType string, isTarget bool) ([]string, error) {
-	var kernelCmdline []string
-
-	if u.Encryption != nil && u.Encryption.Enabled {
-		// LUKS encrypted system - determine which root LUKS UUID to use
-		var rootLUKSUUID string
-		var rootMapperName string
-
-		if isTarget {
-			// Building cmdline for the target (new) root
-			if u.Active {
-				// root1 is active, so target is root2
-				rootLUKSUUID = u.Encryption.Root2LUKSUUID
-				rootMapperName = "root2"
-			} else {
-				// root2 is active, so target is root1
-				rootLUKSUUID = u.Encryption.Root1LUKSUUID
-				rootMapperName = "root1"
-			}
-		} else {
-			// Building cmdline for the active (previous) root
-			if u.Active {
-				// root1 is active
-				rootLUKSUUID = u.Encryption.Root1LUKSUUID
-				rootMapperName = "root1"
-			} else {
-				// root2 is active
-				rootLUKSUUID = u.Encryption.Root2LUKSUUID
-				rootMapperName = "root2"
-			}
-		}
-
-		// Root via device mapper
-		kernelCmdline = append(kernelCmdline, "root=/dev/mapper/"+rootMapperName)
-		kernelCmdline = append(kernelCmdline, "ro")
-
-		// LUKS UUIDs for initramfs to discover and unlock
-		kernelCmdline = append(kernelCmdline, "rd.luks.uuid="+rootLUKSUUID)
-		kernelCmdline = append(kernelCmdline, "rd.luks.name="+rootLUKSUUID+"="+rootMapperName)
-
-		// Var partition via device mapper
-		kernelCmdline = append(kernelCmdline, "rd.luks.uuid="+u.Encryption.VarLUKSUUID)
-		kernelCmdline = append(kernelCmdline, "rd.luks.name="+u.Encryption.VarLUKSUUID+"=var")
-
-		// TPM2 auto-unlock if enabled
-		if u.Encryption.TPM2 {
-			kernelCmdline = append(kernelCmdline, "rd.luks.options="+rootLUKSUUID+"=tpm2-device=auto")
-			kernelCmdline = append(kernelCmdline, "rd.luks.options="+u.Encryption.VarLUKSUUID+"=tpm2-device=auto")
-		}
-
-		// Get boot partition UUID (always FAT32, never encrypted)
-		bootUUID, err := GetPartitionUUID(context.Background(), u.Scheme.BootPartition)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get boot UUID: %w", err)
-		}
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+bootUUID+":/boot:vfat:defaults")
-
-		// Mount /var via systemd.mount-extra using mapper device
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=/dev/mapper/var:/var:"+fsType+":defaults")
-
-		// Enable /etc overlay persistence
-		// The dracut module 95etc-overlay will mount an overlayfs for /etc
-		kernelCmdline = append(kernelCmdline, "rd.etc.overlay=1")
-		kernelCmdline = append(kernelCmdline, "rd.etc.overlay.var=/dev/mapper/var")
-	} else {
-		// Non-encrypted system - use UUID
-		// Get boot partition UUID (always FAT32, never encrypted)
-		bootUUID, err := GetPartitionUUID(context.Background(), u.Scheme.BootPartition)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get boot UUID: %w", err)
-		}
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+bootUUID+":/boot:vfat:defaults")
-
-		kernelCmdline = append(kernelCmdline, "root=UUID="+rootUUID)
-		kernelCmdline = append(kernelCmdline, "ro")
-		kernelCmdline = append(kernelCmdline, "systemd.mount-extra=UUID="+varUUID+":/var:"+fsType+":defaults")
-
-		// Enable /etc overlay persistence
-		// The dracut module 95etc-overlay will mount an overlayfs for /etc
-		kernelCmdline = append(kernelCmdline, "rd.etc.overlay=1")
-		kernelCmdline = append(kernelCmdline, "rd.etc.overlay.var=UUID="+varUUID)
+	bootUUID, err := GetPartitionUUID(context.Background(), u.Scheme.BootPartition)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get boot UUID: %w", err)
 	}
 
-	// HACK: Disable NVMe multipath to ensure stable device naming across reboots
-	// Modern kernels have CONFIG_NVME_MULTIPATH=y by default, causing nvme0/nvme1
-	// to swap between boots due to non-deterministic controller enumeration order.
-	// This is a workaround - ideally we should always use /dev/disk/by-id/* or UUIDs
-	// everywhere and not rely on /dev/nvmeXnY naming at all.
-	// TODO: Audit all code for hardcoded /dev/nvme* paths and migrate to stable identifiers
-	kernelCmdline = append(kernelCmdline, "nvme_core.multipath=N")
+	params := kernelCmdlineParams{
+		FilesystemType: fsType,
+		BootUUID:       bootUUID,
+		ExtraArgs:      u.Config.KernelArgs,
+	}
 
-	// Add user-specified kernel arguments
-	kernelCmdline = append(kernelCmdline, u.Config.KernelArgs...)
+	if u.Encryption != nil && u.Encryption.Enabled {
+		// Pick the root LUKS UUID/mapper for the slot we're building for: the
+		// target (new) root is the inactive slot; otherwise the active one.
+		useRoot2 := (isTarget && u.Active) || (!isTarget && !u.Active)
+		params.Encrypted = true
+		params.TPM2 = u.Encryption.TPM2
+		params.VarLUKSUUID = u.Encryption.VarLUKSUUID
+		if useRoot2 {
+			params.RootMapperName = "root2"
+			params.RootLUKSUUID = u.Encryption.Root2LUKSUUID
+		} else {
+			params.RootMapperName = "root1"
+			params.RootLUKSUUID = u.Encryption.Root1LUKSUUID
+		}
+	} else {
+		params.RootUUID = rootUUID
+		params.VarUUID = varUUID
+	}
 
-	return kernelCmdline, nil
+	return assembleKernelCmdline(params), nil
 }
 
 // PrepareUpdate prepares for an update by detecting partitions and determining target

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -298,17 +298,15 @@ func (u *SystemUpdater) buildKernelCmdline(rootUUID, varUUID, fsType string, isT
 	}
 
 	if u.Encryption != nil && u.Encryption.Enabled {
-		// Pick the root LUKS UUID/mapper for the slot we're building for: the
-		// target (new) root is the inactive slot; otherwise the active one.
-		useRoot2 := (isTarget && u.Active) || (!isTarget && !u.Active)
+		// Pick the root slot the cmdline is being built for (target = inactive).
+		mapperName, useRoot2 := updateRootSlot(isTarget, u.Active)
 		params.Encrypted = true
 		params.TPM2 = u.Encryption.TPM2
 		params.VarLUKSUUID = u.Encryption.VarLUKSUUID
+		params.RootMapperName = mapperName
 		if useRoot2 {
-			params.RootMapperName = "root2"
 			params.RootLUKSUUID = u.Encryption.Root2LUKSUUID
 		} else {
-			params.RootMapperName = "root1"
 			params.RootLUKSUUID = u.Encryption.Root1LUKSUUID
 		}
 	} else {


### PR DESCRIPTION
Fixes #95.

## Problem
`BootloaderInstaller.buildKernelCmdline` (install) and `SystemUpdater.buildKernelCmdline` (update) were two independent implementations of the kernel command line. They produced equivalent output today, but CLAUDE.md's **"Install and Update Parity"** rule warns that nothing *forced* them to stay in sync — a future change to one (a new kernel arg, changed overlay options, the NVMe multipath hack) could silently diverge. The non-encrypted case had in fact already drifted in token order (update emitted the `/boot` mount before `root=`, install after).

## Fix
Extract a single **pure** `assembleKernelCmdline(kernelCmdlineParams) []string` that owns the cmdline format. Both methods now just gather their flow-specific inputs and delegate:
- install always targets the primary slot (`root1`);
- update targets the inactive slot (`root1`/`root2` depending on which is active) — that slot logic is preserved, just simplified.

So the two flows are identical **by construction**; any future format change happens in one place.

## Tests
Adds `pkg/kernelcmdline_test.go` with pure unit tests (no root, no partitions) asserting the **exact** output for non-encrypted, encrypted, and encrypted+TPM2 cases, the `ext4` default, and an explicit install/update parity check. This is stronger coverage than the pre-existing `*WithBootMount` tests, which required root + real partitions and only did substring checks (those still run in CI and pass).

Verified: `build`, `go vet`, `lint` (0 issues), `fmt-check`, and the full non-root suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)