### PR TITLE
fix(update): prune orphan boot kernels/initramfs and remove pairs fully (#105, #109)

### DIFF
--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1045,11 +1045,17 @@ func pruneBootKernelPairs(bootDir, currentVersion, previousVersion string, progr
 		pruned[version] = true
 	}
 
-	// Remove any remaining orphan initramfs files (kernel already gone/absent).
+	// Remove any remaining orphan initramfs files whose kernel is absent. Verify
+	// the kernel is actually gone: if a non-kept kernel's removal failed above,
+	// its vmlinuz still exists, and removing the initramfs here would turn it into
+	// an orphan kernel rather than cleaning one up.
 	for _, initrd := range listBootInitramfs(bootDir) {
 		version := bootInitramfsVersion(filepath.Base(initrd))
 		if version == "" || keep[version] {
 			continue
+		}
+		if _, err := os.Stat(filepath.Join(bootDir, "vmlinuz-"+version)); err == nil {
+			continue // kernel still present; leave the pair alone
 		}
 		note("remove orphan initramfs "+filepath.Base(initrd), os.Remove(initrd))
 		pruned[version] = true

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -959,35 +959,6 @@ func readRunningKernelVersion(path string) (string, error) {
 	return trimmed, nil
 }
 
-type bootKernelPair struct {
-	version string
-	kernel  string
-	initrd  string
-}
-
-func findBootKernelPairs(bootDir string) ([]bootKernelPair, error) {
-	kernels, err := filepath.Glob(filepath.Join(bootDir, "vmlinuz-*"))
-	if err != nil {
-		return nil, err
-	}
-
-	pairs := make([]bootKernelPair, 0, len(kernels))
-	for _, kernel := range kernels {
-		version := strings.TrimPrefix(filepath.Base(kernel), "vmlinuz-")
-		initrd, ok := findBootInitramfs(bootDir, version)
-		if !ok {
-			continue
-		}
-		pairs = append(pairs, bootKernelPair{
-			version: version,
-			kernel:  kernel,
-			initrd:  initrd,
-		})
-	}
-
-	return pairs, nil
-}
-
 func findBootInitramfs(bootDir, version string) (string, bool) {
 	patterns := []string{
 		filepath.Join(bootDir, "initramfs-"+version+".img"),
@@ -1002,34 +973,92 @@ func findBootInitramfs(bootDir, version string) (string, bool) {
 	return "", false
 }
 
-func pruneBootKernelPairs(bootDir, currentVersion, previousVersion string, progress reporter.Reporter) error {
-	pairs, err := findBootKernelPairs(bootDir)
-	if err != nil {
-		return fmt.Errorf("failed to find boot kernel pairs: %w", err)
+// bootInitramfsVersion extracts the kernel version from an initramfs filename,
+// reversing the naming patterns findBootInitramfs looks for. Returns "" if the
+// name is not a recognized initramfs.
+func bootInitramfsVersion(base string) string {
+	switch {
+	case strings.HasPrefix(base, "initramfs-") && strings.HasSuffix(base, ".img"):
+		return strings.TrimSuffix(strings.TrimPrefix(base, "initramfs-"), ".img")
+	case strings.HasPrefix(base, "initrd.img-"):
+		return strings.TrimPrefix(base, "initrd.img-")
+	case strings.HasPrefix(base, "initramfs-"):
+		return strings.TrimPrefix(base, "initramfs-")
 	}
+	return ""
+}
 
-	keep := map[string]bool{
-		currentVersion: true,
+// listBootInitramfs returns every initramfs file in bootDir (de-duplicated
+// across the overlapping glob patterns).
+func listBootInitramfs(bootDir string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, pattern := range []string{"initramfs-*.img", "initrd.img-*", "initramfs-*"} {
+		matches, _ := filepath.Glob(filepath.Join(bootDir, pattern))
+		for _, m := range matches {
+			if !seen[m] {
+				seen[m] = true
+				out = append(out, m)
+			}
+		}
 	}
+	return out
+}
+
+// pruneBootKernelPairs removes kernel and initramfs files whose version is
+// neither the current nor the previous kernel. It also removes orphans -- a
+// kernel with no initramfs, or an initramfs with no kernel, is not bootable and
+// is only cruft (this is what leaves stale vmlinuz-* accumulating over update
+// cycles). A version's kernel and initramfs are removed independently so a
+// failure on one does not leave the other behind; the first error is returned
+// after attempting all removals. Non-kernel files (e.g. loader.conf) are never
+// touched.
+func pruneBootKernelPairs(bootDir, currentVersion, previousVersion string, progress reporter.Reporter) error {
+	keep := map[string]bool{currentVersion: true}
 	if previousVersion != "" {
 		keep[previousVersion] = true
 	}
 
-	for _, pair := range pairs {
-		if keep[pair.version] {
-			continue
+	var firstErr error
+	note := func(context string, err error) {
+		if err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = fmt.Errorf("%s: %w", context, err)
 		}
-
-		if err := os.Remove(pair.kernel); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove old kernel %s: %w", filepath.Base(pair.kernel), err)
-		}
-		if err := os.Remove(pair.initrd); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove old initramfs %s: %w", filepath.Base(pair.initrd), err)
-		}
-		progress.Message("Pruned old boot kernel pair: %s", pair.version)
 	}
 
-	return nil
+	pruned := map[string]bool{}
+
+	// Remove non-kept kernels, including orphans with no initramfs.
+	kernels, err := filepath.Glob(filepath.Join(bootDir, "vmlinuz-*"))
+	if err != nil {
+		return fmt.Errorf("failed to list boot kernels: %w", err)
+	}
+	for _, kernel := range kernels {
+		version := strings.TrimPrefix(filepath.Base(kernel), "vmlinuz-")
+		if keep[version] {
+			continue
+		}
+		note("remove old kernel "+filepath.Base(kernel), os.Remove(kernel))
+		if initrd, ok := findBootInitramfs(bootDir, version); ok {
+			note("remove old initramfs "+filepath.Base(initrd), os.Remove(initrd))
+		}
+		pruned[version] = true
+	}
+
+	// Remove any remaining orphan initramfs files (kernel already gone/absent).
+	for _, initrd := range listBootInitramfs(bootDir) {
+		version := bootInitramfsVersion(filepath.Base(initrd))
+		if version == "" || keep[version] {
+			continue
+		}
+		note("remove orphan initramfs "+filepath.Base(initrd), os.Remove(initrd))
+		pruned[version] = true
+	}
+
+	for version := range pruned {
+		progress.Message("Pruned old boot kernel: %s", version)
+	}
+	return firstErr
 }
 
 func getBootInitramfsName(bootDir, version string) (string, error) {

--- a/pkg/update_test.go
+++ b/pkg/update_test.go
@@ -1037,9 +1037,9 @@ func TestPruneBootKernelPairsRemovesOrphans(t *testing.T) {
 	}
 }
 
-// TestPruneBootKernelPairsRemovesBothOnError ensures a version's kernel and
-// initramfs are both attempted even if one removal is a no-op, so no orphan is
-// left behind (#109).
+// TestPruneBootKernelPairsRemovesBothOfAPair ensures both the kernel and the
+// initramfs of a pruned old version are removed, so a pair is never left
+// half-removed (#109).
 func TestPruneBootKernelPairsRemovesBothOfAPair(t *testing.T) {
 	bootDir := t.TempDir()
 	// One old complete pair to prune.

--- a/pkg/update_test.go
+++ b/pkg/update_test.go
@@ -989,7 +989,7 @@ func TestPruneBootKernelPairsKeepsCurrentAndPrevious(t *testing.T) {
 	}
 }
 
-func TestPruneBootKernelPairsLeavesIncompletePairs(t *testing.T) {
+func TestPruneBootKernelPairsRemovesOrphans(t *testing.T) {
 	bootDir := t.TempDir()
 
 	completeVersions := []string{"6.18.2-previous", "6.18.3-current"}
@@ -1002,14 +1002,13 @@ func TestPruneBootKernelPairsLeavesIncompletePairs(t *testing.T) {
 		}
 	}
 
-	orphans := []string{
-		"vmlinuz-6.18.0-orphan",
-		"initramfs-6.18.1-orphan.img",
-		"loader.conf",
-	}
-	for _, orphan := range orphans {
-		if err := os.WriteFile(filepath.Join(bootDir, orphan), []byte("orphan"), 0644); err != nil {
-			t.Fatalf("Failed to write orphan file: %v", err)
+	// An orphan kernel (no initramfs) and an orphan initramfs (no kernel) are not
+	// bootable and must be pruned; unrelated files must be left alone.
+	orphans := []string{"vmlinuz-6.18.0-orphan", "initramfs-6.18.1-orphan.img"}
+	keepUnrelated := []string{"loader.conf"}
+	for _, f := range append(append([]string{}, orphans...), keepUnrelated...) {
+		if err := os.WriteFile(filepath.Join(bootDir, f), []byte("x"), 0644); err != nil {
+			t.Fatalf("Failed to write %s: %v", f, err)
 		}
 	}
 
@@ -1018,8 +1017,44 @@ func TestPruneBootKernelPairsLeavesIncompletePairs(t *testing.T) {
 	}
 
 	for _, orphan := range orphans {
-		if _, err := os.Stat(filepath.Join(bootDir, orphan)); err != nil {
-			t.Errorf("Expected incomplete/unrelated file %s to remain: %v", orphan, err)
+		if _, err := os.Stat(filepath.Join(bootDir, orphan)); !os.IsNotExist(err) {
+			t.Errorf("expected orphan %s to be pruned, stat err = %v", orphan, err)
+		}
+	}
+	for _, f := range keepUnrelated {
+		if _, err := os.Stat(filepath.Join(bootDir, f)); err != nil {
+			t.Errorf("expected unrelated file %s to remain: %v", f, err)
+		}
+	}
+	// Current and previous kernels/initramfs must remain.
+	for _, version := range completeVersions {
+		if _, err := os.Stat(filepath.Join(bootDir, "vmlinuz-"+version)); err != nil {
+			t.Errorf("expected kept kernel %s to remain: %v", version, err)
+		}
+		if _, err := os.Stat(filepath.Join(bootDir, "initrd.img-"+version)); err != nil {
+			t.Errorf("expected kept initramfs %s to remain: %v", version, err)
+		}
+	}
+}
+
+// TestPruneBootKernelPairsRemovesBothOnError ensures a version's kernel and
+// initramfs are both attempted even if one removal is a no-op, so no orphan is
+// left behind (#109).
+func TestPruneBootKernelPairsRemovesBothOfAPair(t *testing.T) {
+	bootDir := t.TempDir()
+	// One old complete pair to prune.
+	if err := os.WriteFile(filepath.Join(bootDir, "vmlinuz-6.0.0-old"), []byte("k"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bootDir, "initramfs-6.0.0-old.img"), []byte("i"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := pruneBootKernelPairs(bootDir, "7.0.0-current", "", reporter.NoopReporter{}); err != nil {
+		t.Fatalf("prune failed: %v", err)
+	}
+	for _, f := range []string{"vmlinuz-6.0.0-old", "initramfs-6.0.0-old.img"} {
+		if _, err := os.Stat(filepath.Join(bootDir, f)); !os.IsNotExist(err) {
+			t.Errorf("expected %s removed, stat err = %v", f, err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #105 and #109.

## Problems
- **#105:** `pruneBootKernelPairs` only looked at *complete* pairs (`findBootKernelPairs` skipped any kernel with no matching initramfs). So an orphan `vmlinuz-*` (kernel with no initramfs) was never pruned and accumulated forever on the ESP. Confirmed live: `/boot/vmlinuz-6.19.11+deb13-amd64` with no matching initramfs.
- **#109:** It removed a pair's kernel then its initramfs with an early `return` between them, so a failure on the second removal left the kernel deleted but the initramfs behind (an orphan).

## Fix
Rewrote pruning to:
- enumerate all `vmlinuz-*` directly and remove any whose version isn't the current/previous kernel — **including orphans**. (An orphan kernel has no initramfs and isn't bootable, so it's pure cruft; the keep-set still protects current+previous.)
- sweep orphan `initramfs`/`initrd.img` files whose kernel is already gone;
- attempt a version's kernel and initramfs removals **independently**, returning the first error only after trying all, so nothing is left half-removed.

Non-kernel files (e.g. `loader.conf`) are never touched. Removed the now-unused `findBootKernelPairs`/`bootKernelPair`.

## Behavior change note
The previous behavior (locked by `TestPruneBootKernelPairsLeavesIncompletePairs`) deliberately *retained* orphans. That's the accumulation bug #105 describes, so this PR intentionally flips it — an orphan kernel/initramfs is non-bootable and safe to remove. The test is rewritten accordingly (`TestPruneBootKernelPairsRemovesOrphans`), asserting orphans are pruned while unrelated files and current/previous are kept.

Verified: `build`, `go vet`, `lint` (0 issues), `fmt-check`, and the prune tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)