### PR TITLE
fix(download): guard digest slice against short digests (#104)

### DIFF
--- a/cmd/download.go
+++ b/cmd/download.go
@@ -124,7 +124,7 @@ func runDownload(cmd *cobra.Command, args []string) error {
 			if clix.JSONOutput {
 				return clix.OutputJSONError("no update available", fmt.Errorf("image digest matches installed version"))
 			}
-			return fmt.Errorf("no update available: image digest matches installed version (%s)", remoteDigest[:19]+"...")
+			return fmt.Errorf("no update available: image digest matches installed version (%s)", remoteDigest[:min(19, len(remoteDigest))]+"...")
 		}
 
 		if !clix.JSONOutput {


### PR DESCRIPTION
Fixes #104.

The "no update available" branch in `cmd/download.go` sliced `remoteDigest[:19]` without a length guard, while the neighboring lines (and `cmd/update.go`) already use `remoteDigest[:min(19, len(remoteDigest))]`. A short/malformed digest (e.g. an unexpected registry response or non-standard digest algorithm) would panic with index-out-of-range instead of erroring cleanly. Uses the same `min()` guard for consistency.

Verified: `build`, `lint` (0), `fmt-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)