### PR TITLE
fix(bootloader): avoid zero-entry window when regenerating systemd-boot entry (#108)

### DIFF
--- a/pkg/bootloader.go
+++ b/pkg/bootloader.go
@@ -678,13 +678,7 @@ editor yes
 		return fmt.Errorf("failed to write loader.conf: %w", err)
 	}
 
-	// Remove any existing boot entries (from container image or bootctl install)
 	entriesDir := filepath.Join(loaderDir, "entries")
-	if entries, err := filepath.Glob(filepath.Join(entriesDir, "*.conf")); err == nil {
-		for _, entry := range entries {
-			_ = os.Remove(entry)
-		}
-	}
 	if err := os.MkdirAll(entriesDir, 0755); err != nil {
 		return fmt.Errorf("failed to create entries directory: %w", err)
 	}
@@ -695,9 +689,22 @@ initrd  /%s
 options %s
 `, b.OSName, kernelVersion, initrd, strings.Join(kernelCmdline, " "))
 
+	// Write our entry BEFORE removing any others, so the ESP is never left with
+	// zero boot entries (a crash in that window would leave nothing to boot).
 	entryPath := filepath.Join(entriesDir, "bootc.conf")
 	if err := atomicWriteFile(entryPath, []byte(entry), 0644); err != nil {
 		return fmt.Errorf("failed to write boot entry: %w", err)
+	}
+
+	// Now remove any other existing boot entries (from the container image or a
+	// bootctl install), keeping the one we just wrote.
+	if entries, err := filepath.Glob(filepath.Join(entriesDir, "*.conf")); err == nil {
+		for _, existing := range entries {
+			if filepath.Base(existing) == "bootc.conf" {
+				continue
+			}
+			_ = os.Remove(existing)
+		}
 	}
 
 	b.Progress.Message("Created boot entry: %s", b.OSName)


### PR DESCRIPTION
Fixes #108.

## Problem
`generateSystemdBootConfig` (install path) removed **all** `entries/*.conf` and *then* wrote the new `bootc.conf`. Between the delete and the write there's a window where the ESP has zero boot entries — a crash/power loss there leaves nothing to boot.

## Fix
Write `bootc.conf` first (atomically, via the existing `atomicWriteFile`), then remove the other stale entries (from the container image or a `bootctl install`), **keeping** the one just written. So there's always at least one valid entry on the ESP.

## Scope
The fsync half of #108 was already handled by the atomic-write work in #87/#116; this closes the remaining ordering gap. The **update** path already overwrites `bootc.conf`/`bootc-previous.conf` in place (no delete-all step), so it doesn't have this window.

Verified: `build`, `vet`, `lint` (0), `fmt-check`, and the bootloader config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)