### PR TITLE
fix(install): evict staged-install cache after a successful real-disk install (#106)

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -134,6 +134,18 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// A staged-install image consumed by a real-disk install has served its
+	// purpose; evict it so it doesn't accumulate in /var/cache indefinitely.
+	// Loopback builds are skipped since they are commonly repeated from the same
+	// staged image. Best-effort: never fail the install over cleanup (e.g. the
+	// staged image may live on read-only install media).
+	if result != nil && result.LoopbackPath == "" && cfg.LocalImage != nil &&
+		strings.HasPrefix(cfg.LocalImage.LayoutPath, pkg.StagedInstallDir) {
+		if clearErr := pkg.NewStagedInstallCache().Clear(cmd.Context(), clix.NewReporter()); clearErr != nil && !clix.JSONOutput {
+			fmt.Fprintf(os.Stderr, "Note: could not clear staged-install cache: %v\n", clearErr)
+		}
+	}
+
 	// Print loopback usage instructions
 	if result.LoopbackPath != "" && !clix.JSONOutput {
 		fmt.Println()

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/frostyard/clix"
 	"github.com/frostyard/nbc/pkg"
+	"github.com/frostyard/std/reporter"
 	"github.com/spf13/cobra"
 )
 
@@ -136,12 +137,14 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	// A staged-install image consumed by a real-disk install has served its
 	// purpose; evict it so it doesn't accumulate in /var/cache indefinitely.
-	// Loopback builds are skipped since they are commonly repeated from the same
-	// staged image. Best-effort: never fail the install over cleanup (e.g. the
-	// staged image may live on read-only install media).
-	if result != nil && result.LoopbackPath == "" && cfg.LocalImage != nil &&
-		strings.HasPrefix(cfg.LocalImage.LayoutPath, pkg.StagedInstallDir) {
-		if clearErr := pkg.NewStagedInstallCache().Clear(cmd.Context(), clix.NewReporter()); clearErr != nil && !clix.JSONOutput {
+	// Skipped for dry-run (nothing was installed) and loopback builds (commonly
+	// repeated from the same staged image). Best-effort: never fail the install
+	// over cleanup (e.g. the staged image may live on read-only install media),
+	// and stay silent so it can't interfere with the JSON output stream.
+	usedStagedImage := cfg.LocalImage != nil &&
+		strings.HasPrefix(cfg.LocalImage.LayoutPath, pkg.StagedInstallDir+string(os.PathSeparator))
+	if result != nil && !clix.DryRun && result.LoopbackPath == "" && usedStagedImage {
+		if clearErr := pkg.NewStagedInstallCache().Clear(cmd.Context(), reporter.NoopReporter{}); clearErr != nil && !clix.JSONOutput {
 			fmt.Fprintf(os.Stderr, "Note: could not clear staged-install cache: %v\n", clearErr)
 		}
 	}


### PR DESCRIPTION
Fixes #106.

## Problem
The staged-install image (`/var/cache/nbc/staged-install`) is consumed at install time but was never cleaned up, so it sat in `/var/cache` indefinitely — a multi-GB image was observed still present long after the original install.

## Fix
Mirror what the update flow already does (it clears the staged-update cache after applying): after a **successful real-disk install that used a staged image**, clear the staged-install cache.

- **Best-effort:** never fails the install over cleanup — e.g. the staged image may live on read-only install media, where `Clear` can't remove it.
- **Loopback builds are skipped**, since building multiple loopback images from the same staged image is a common workflow; only terminal real-disk installs evict.

Detection uses `cfg.LocalImage.LayoutPath` being under `pkg.StagedInstallDir`, which is where both the `--local-image` and auto-detect paths source the image.

Verified: `build`, `vet`, `lint` (0), `fmt-check`.

> Note: the staged-**update** half of this issue was already handled (cmd/update.go clears the staged-update cache after a successful apply); this closes the staged-**install** half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)