### PR TITLE
fix: exit cleanly on non-nbc (bootc/composefs) systems during update

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -151,6 +151,29 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		// Auto-detect boot device
 		device, err = pkg.GetCurrentBootDeviceInfo(cmd.Context(), clix.Verbose, progress)
 		if err != nil {
+			// If this host is managed by something other than nbc (e.g. a
+			// bootc/composefs install), there is nothing to update — exit
+			// cleanly so scheduled callers don't accumulate failed units.
+			if pkg.IsNonNBCSystem() {
+				const msg = "System is not nbc-managed (bootc/composefs detected), nothing to do"
+				if clix.JSONOutput {
+					if updFlags.checkOnly {
+						clix.OutputJSON(types.UpdateCheckOutput{
+							UpdateNeeded: false,
+							Message:      msg,
+						})
+					} else {
+						clix.OutputJSON(map[string]any{
+							"success": true,
+							"skipped": true,
+							"message": msg,
+						})
+					}
+				} else {
+					fmt.Println(msg)
+				}
+				return nil
+			}
 			if clix.JSONOutput {
 				progress.Error(err, "Failed to auto-detect boot device")
 			}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -69,6 +69,28 @@ func GetActiveRootPartition() (string, error) {
 	return "", fmt.Errorf("could not determine active root partition from kernel command line")
 }
 
+// IsNonNBCCmdline reports whether a kernel command line indicates a system
+// managed by something other than nbc, such as a bootc/composefs install.
+func IsNonNBCCmdline(cmdline string) bool {
+	for field := range strings.FieldsSeq(cmdline) {
+		if field == "composefs" || strings.HasPrefix(field, "composefs=") {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNonNBCSystem reads /proc/cmdline and reports whether the running system
+// appears to be managed by something other than nbc (e.g. bootc/composefs).
+// Returns false if /proc/cmdline cannot be read.
+func IsNonNBCSystem() bool {
+	cmdline, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return false
+	}
+	return IsNonNBCCmdline(string(cmdline))
+}
+
 // IsRootMountedReadOnly checks if the root partition is mounted read-only
 // Returns "ro" for read-only, "rw" for read-write, or empty string if unable to determine
 func IsRootMountedReadOnly() string {

--- a/pkg/update_test.go
+++ b/pkg/update_test.go
@@ -1146,3 +1146,50 @@ func readConfigFromFile(path string) (*SystemConfig, error) {
 
 	return &config, nil
 }
+
+func TestIsNonNBCCmdline(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		{
+			name:    "bootc composefs system",
+			cmdline: `initrd=\EFI\Linux\bootc_composefs-abc123\initrd root=LABEL=root rw composefs=abc123 rhgb quiet rd.luks.name=deadbeef=root`,
+			want:    true,
+		},
+		{
+			name:    "bare composefs flag",
+			cmdline: "root=LABEL=root rw composefs quiet",
+			want:    true,
+		},
+		{
+			name:    "nbc system with root UUID",
+			cmdline: "root=UUID=abc-123 rw systemd.mount-extra=UUID=def-456:/var:ext4:defaults",
+			want:    false,
+		},
+		{
+			name:    "nbc system with device path root",
+			cmdline: "root=/dev/sda2 rw quiet",
+			want:    false,
+		},
+		{
+			name:    "composefs as substring of another param does not match",
+			cmdline: "root=UUID=abc-123 rw rd.composefs.enabled=1",
+			want:    false,
+		},
+		{
+			name:    "empty cmdline",
+			cmdline: "",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNonNBCCmdline(tt.cmdline); got != tt.want {
+				t.Errorf("IsNonNBCCmdline(%q) = %v, want %v", tt.cmdline, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #139

## Problem

On bootc/composefs-installed hosts, `nbc update` (and `--download-only`, as run hourly by `nbc-update-download.service`) fails with:

```
Failed to auto-detect boot device: failed to determine active root partition: could not determine
active root partition from kernel command line (use --device to specify manually)
```

The kernel cmdline on those systems (`root=LABEL=root ... composefs=<digest>`) gives nbc's root-partition detection nothing to find — the host simply isn't nbc-managed. Every scheduled run leaves a failed unit, putting the system in `degraded` state and masking real failures.

## Fix

When boot-device auto-detection fails during `nbc update`, check for the positive "not ours" signal: a `composefs=<digest>` (or bare `composefs`) parameter on `/proc/cmdline`. If present, print an informational message and exit 0 instead of erroring. This mirrors how snosi's `bootc-update-stage` no-ops on nbc installs.

- New `pkg.IsNonNBCCmdline(cmdline)` (pure, unit-tested) and `pkg.IsNonNBCSystem()` reading `/proc/cmdline`
- Wired into the auto-detect failure path in `cmd/update.go`, covering `update`, `--check`, and `--download-only`, with sensible `--json` output in each mode
- Detection failures **without** the composefs signal still exit 1 exactly as before, and `--device` overrides are unaffected

## Verification

Exercised the built binary under `unshare -rm` with a bind-mounted fake `/proc/cmdline`:

- bootc composefs cmdline (from the issue): `nbc update`, `--download-only`, `--json`, and `--check --json` all print "System is not nbc-managed (bootc/composefs detected), nothing to do" and exit 0
- undetectable cmdline *without* `composefs=`: still errors with exit 1 (unchanged)
- `make fmt`, `make lint` (0 issues), `make build`, and unit tests pass (`TestCache*` lock-permission failures are pre-existing on main in this environment, requiring root-writable `/var/run/nbc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)