### PR TITLE
fix: probe actual cache lock acquisition in unprivileged test skip helper

### DIFF
--- a/pkg/cache_test.go
+++ b/pkg/cache_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,11 +59,19 @@ func assertMetadataEqual(t *testing.T, got, want *CachedImageMetadata) {
 func skipIfNoCacheLockPermission(t *testing.T) {
 	t.Helper()
 
-	if err := ensureLockDir(); err != nil {
-		if os.IsPermission(err) || strings.Contains(err.Error(), "permission denied") {
-			t.Skip("Skipping test: no permission to create /var/run/nbc")
+	// Attempt the actual lock acquisition rather than just probing the lock
+	// directory: /var/run/nbc may already exist root-owned (created by a
+	// prior sudo integration-test run), in which case creating the directory
+	// succeeds but opening the lock file as an unprivileged user does not.
+	lock, err := AcquireCacheLockShared()
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) || strings.Contains(err.Error(), "permission denied") {
+			t.Skip("Skipping test: no permission to use cache lock in /var/run/nbc")
 		}
-		t.Fatalf("ensureLockDir failed: %v", err)
+		t.Fatalf("AcquireCacheLockShared failed: %v", err)
+	}
+	if err := lock.Release(); err != nil {
+		t.Fatalf("failed to release cache lock: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`make bump` (via its `make test` gate) fails on any machine where `/var/run/nbc` exists root-owned — which is exactly the state a prior `sudo` integration-test run leaves behind, since `/var/run` is tmpfs and the directory persists until reboot:

```
--- FAIL: TestCacheCommitDownload_AtomicMove
    cache_test.go:162: AcquireCacheLockShared() during staging failed:
    failed to open lock file /var/run/nbc/cache.lock: permission denied
```

`skipIfNoCacheLockPermission` was meant to skip these five cache tests when running unprivileged, but it only probed `ensureLockDir()` (`os.MkdirAll`), which succeeds when the directory already exists regardless of ownership. The tests then failed at the real lock acquisition. Net effect: the first `make bump` after a reboot works, and every subsequent one in the same boot session fails at `test-unit`.

## Fix

Make the helper attempt `AcquireCacheLockShared()` itself — the operation the tests actually depend on — and skip on permission errors (releasing the lock on success). Test-only change.

## Verification

- Armed environment (root-owned `/var/run/nbc`, running as uid 1000): the five tests now **SKIP** (previously FAIL); `make test-unit` passes
- Writable lock dir (fresh tmpfs `/var/run` via `unshare -rm`, `-count=1`): the five tests still **run and PASS**, confirming the skip doesn't hide them when the lock is acquirable
- `make fmt` / `make lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)